### PR TITLE
Fix Astro docs build by externalizing sharp

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -11,9 +11,4 @@ export default defineConfig({
       external: ["sharp"],
     },
   },
-  image: {
-    service: {
-      entrypoint: "astro/assets/services/squoosh",
-    },
-  },
 });

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -1,0 +1,19 @@
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  vite: {
+    build: {
+      rollupOptions: {
+        external: ["sharp"],
+      },
+    },
+    ssr: {
+      external: ["sharp"],
+    },
+  },
+  image: {
+    service: {
+      entrypoint: "astro/assets/services/squoosh",
+    },
+  },
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - packages/core
   - packages/types
   - packages/mcp-docs-server
+  - packages/docs


### PR DESCRIPTION
## Summary
- add an Astro configuration for the docs package that externalizes the sharp dependency and switches to the squoosh image service
- register the docs workspace so the configuration is picked up during installs

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_b_68dffcd1abf083259c4a55a16ef239e4