### PR TITLE
Add while step support to workflow engine

### DIFF
--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -25,6 +25,14 @@ export {
 } from "./steps/forEachStep.js";
 export type { ForEachCollectFn, ForEachStepConfig, ForEachStepOutput } from "./steps/forEachStep.js";
 
+export { createWhileStep } from "./steps/whileStep.js";
+export type {
+  WhileCollectFn,
+  WhileLoopState,
+  WhileStepConfig,
+  WhileStepOutput,
+} from "./steps/whileStep.js";
+
 export { createConditionStep } from "./steps/conditionStep.js";
 export type { ConditionStepConfig } from "./steps/conditionStep.js";
 

--- a/packages/core/src/workflows/steps/whileStep.test.ts
+++ b/packages/core/src/workflows/steps/whileStep.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import { WorkflowAbortError, WorkflowExecutionError } from "../errors.js";
+import type { WorkflowStepContext } from "../types.js";
+import { createStep } from "./step.js";
+import {
+  createWhileStep,
+  type WhileLoopState,
+} from "./whileStep.js";
+
+const createTestContext = (): WorkflowStepContext => {
+  let metadata: Record<string, unknown> = {};
+
+  return {
+    workflowId: "workflow",
+    runId: "run",
+    initialInput: undefined,
+    store: new Map<string, unknown>(),
+    getMetadata() {
+      return metadata;
+    },
+    updateMetadata(updater) {
+      metadata = updater(metadata);
+    },
+    emit() {
+      // no-op
+    },
+  };
+};
+
+describe("createWhileStep", () => {
+  it("executes the body while the condition is true and returns the last output", async () => {
+    const conditionStep = createStep<WhileLoopState<number, number>, boolean>({
+      id: "condition",
+      handler: ({ input }) => input.iteration < input.initialInput,
+    });
+
+    const bodyStep = createStep<WhileLoopState<number, number>, number>({
+      id: "body",
+      handler: ({ input }) => (input.lastOutput ?? 0) + 1,
+    });
+
+    const whileStep = createWhileStep<number, number, typeof conditionStep, typeof bodyStep>({
+      id: "while",
+      condition: conditionStep,
+      body: bodyStep,
+    });
+
+    const controller = new AbortController();
+    const result = await whileStep.execute({
+      input: 3,
+      context: createTestContext(),
+      signal: controller.signal,
+    });
+
+    expect(result.output).toBe(3);
+  });
+
+  it("aggregates outputs with the collect function when provided", async () => {
+    const conditionStep = createStep<WhileLoopState<number, number>, boolean>({
+      id: "condition",
+      handler: ({ input }) => input.iteration < input.initialInput,
+    });
+
+    const bodyStep = createStep<WhileLoopState<number, number>, number>({
+      id: "body",
+      handler: ({ input }) => (input.lastOutput ?? 0) + 1,
+    });
+
+    const whileStep = createWhileStep<number, number, typeof conditionStep, typeof bodyStep>({
+      id: "while",
+      condition: conditionStep,
+      body: bodyStep,
+      collect: async (outputs) => outputs.reduce((sum, value) => sum + value, 0),
+    });
+
+    const controller = new AbortController();
+    const result = await whileStep.execute({
+      input: 3,
+      context: createTestContext(),
+      signal: controller.signal,
+    });
+
+    expect(result.output).toBe(6);
+  });
+
+  it("respects abort signals between iterations", async () => {
+    const controller = new AbortController();
+
+    const conditionStep = createStep<WhileLoopState<number, number>, boolean>({
+      id: "condition",
+      handler: ({ input }) => input.iteration < 5,
+    });
+
+    const bodyStep = createStep<WhileLoopState<number, number>, number>({
+      id: "body",
+      handler: ({ input }) => {
+        if (input.iteration === 0) {
+          controller.abort(new WorkflowAbortError("cancelled"));
+        }
+
+        return (input.lastOutput ?? 0) + 1;
+      },
+    });
+
+    const whileStep = createWhileStep<number, number, typeof conditionStep, typeof bodyStep>({
+      id: "while",
+      condition: conditionStep,
+      body: bodyStep,
+    });
+
+    await expect(
+      whileStep.execute({
+        input: 3,
+        context: createTestContext(),
+        signal: controller.signal,
+      }),
+    ).rejects.toBeInstanceOf(WorkflowAbortError);
+  });
+
+  it("throws when exceeding the maximum iterations", async () => {
+    const conditionStep = createStep<WhileLoopState<number, number>, boolean>({
+      id: "condition",
+      handler: () => true,
+    });
+
+    const bodyStep = createStep<WhileLoopState<number, number>, number>({
+      id: "body",
+      handler: ({ input }) => (input.lastOutput ?? 0) + 1,
+    });
+
+    const whileStep = createWhileStep<number, number, typeof conditionStep, typeof bodyStep>({
+      id: "while",
+      condition: conditionStep,
+      body: bodyStep,
+      maxIterations: 2,
+    });
+
+    const controller = new AbortController();
+
+    await expect(
+      whileStep.execute({
+        input: 3,
+        context: createTestContext(),
+        signal: controller.signal,
+      }),
+    ).rejects.toBeInstanceOf(WorkflowExecutionError);
+  });
+
+  it("validates that the condition resolves to a boolean", async () => {
+    const conditionStep = createStep<WhileLoopState<number, number>, boolean>({
+      id: "condition",
+      handler: () => "not-a-boolean" as unknown as boolean,
+    });
+
+    const bodyStep = createStep<WhileLoopState<number, number>, number>({
+      id: "body",
+      handler: ({ input }) => (input.lastOutput ?? 0) + 1,
+    });
+
+    const whileStep = createWhileStep<number, number, typeof conditionStep, typeof bodyStep>({
+      id: "while",
+      condition: conditionStep,
+      body: bodyStep,
+    });
+
+    const controller = new AbortController();
+
+    await expect(
+      whileStep.execute({
+        input: 3,
+        context: createTestContext(),
+        signal: controller.signal,
+      }),
+    ).rejects.toBeInstanceOf(WorkflowExecutionError);
+  });
+});

--- a/packages/core/src/workflows/steps/whileStep.ts
+++ b/packages/core/src/workflows/steps/whileStep.ts
@@ -1,0 +1,198 @@
+import { WorkflowAbortError, WorkflowExecutionError } from "../errors.js";
+import type { MaybePromise, SchemaLike, StepHandlerArgs } from "../types.js";
+import { createStep, type WorkflowStep } from "./step.js";
+
+export interface WhileLoopState<Input, BodyOutput> {
+  initialInput: Input;
+  iteration: number;
+  lastOutput?: BodyOutput;
+}
+
+export type WhileCollectFn<BodyOutput> = (
+  outputs: BodyOutput[],
+) => MaybePromise<unknown>;
+
+export type WhileStepOutput<
+  BodyOutput,
+  Collect extends WhileCollectFn<BodyOutput> | undefined,
+> = Collect extends WhileCollectFn<BodyOutput>
+  ? Awaited<ReturnType<Collect>>
+  : BodyOutput | undefined;
+
+export interface WhileStepConfig<
+  Input,
+  BodyOutput,
+  ConditionStep extends WorkflowStep<
+    WhileLoopState<Input, BodyOutput>,
+    boolean,
+    Meta,
+    RootInput
+  >,
+  BodyStep extends WorkflowStep<
+    WhileLoopState<Input, BodyOutput>,
+    BodyOutput,
+    Meta,
+    RootInput
+  >,
+  Meta extends Record<string, unknown> = Record<string, unknown>,
+  RootInput = unknown,
+  Collect extends WhileCollectFn<BodyOutput> | undefined = undefined,
+> {
+  id: string;
+  description?: string;
+  inputSchema?: SchemaLike<Input>;
+  outputSchema?: SchemaLike<WhileStepOutput<BodyOutput, Collect>>;
+  condition: ConditionStep;
+  body: BodyStep;
+  collect?: Collect;
+  maxIterations?: number;
+}
+
+const normalizeMaxIterations = (value: number | undefined) => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Number.isFinite(value)) {
+    return undefined;
+  }
+
+  const normalized = Math.floor(value);
+
+  if (normalized <= 0) {
+    throw new WorkflowExecutionError(
+      "While step maxIterations must be a positive finite number",
+    );
+  }
+
+  return normalized;
+};
+
+export const createWhileStep = <
+  Input,
+  BodyOutput,
+  ConditionStep extends WorkflowStep<
+    WhileLoopState<Input, BodyOutput>,
+    boolean,
+    Meta,
+    RootInput
+  >,
+  BodyStep extends WorkflowStep<
+    WhileLoopState<Input, BodyOutput>,
+    BodyOutput,
+    Meta,
+    RootInput
+  >,
+  Meta extends Record<string, unknown> = Record<string, unknown>,
+  RootInput = unknown,
+  Collect extends WhileCollectFn<BodyOutput> | undefined = undefined,
+>(
+  config: WhileStepConfig<
+    Input,
+    BodyOutput,
+    ConditionStep,
+    BodyStep,
+    Meta,
+    RootInput,
+    Collect
+  >,
+) =>
+  createStep<Input, WhileStepOutput<BodyOutput, Collect>, Meta, RootInput>({
+    id: config.id,
+    description: config.description,
+    inputSchema: config.inputSchema,
+    outputSchema: config.outputSchema,
+    handler: async (args: StepHandlerArgs<Input, Meta, RootInput>) => {
+      const maxIterations = normalizeMaxIterations(config.maxIterations);
+
+      const outputs: BodyOutput[] = [];
+      let lastOutput: BodyOutput | undefined;
+      let iteration = 0;
+
+      while (true) {
+        if (args.signal.aborted) {
+          throw args.signal.reason ?? new WorkflowAbortError();
+        }
+
+        const loopState: WhileLoopState<Input, BodyOutput> = {
+          initialInput: args.input,
+          iteration,
+          lastOutput,
+        };
+
+        const conditionArgs: StepHandlerArgs<
+          WhileLoopState<Input, BodyOutput>,
+          Meta,
+          RootInput
+        > = {
+          context: args.context,
+          signal: args.signal,
+          input: loopState,
+        };
+
+        let shouldContinue: boolean;
+
+        try {
+          const { output } = await config.condition.execute(conditionArgs);
+          shouldContinue = output;
+        } catch (error) {
+          throw new WorkflowExecutionError(
+            `While step ${config.id} failed while evaluating condition at iteration ${iteration}`,
+            error,
+          );
+        }
+
+        if (typeof shouldContinue !== "boolean") {
+          throw new WorkflowExecutionError(
+            `While step ${config.id} condition must return a boolean at iteration ${iteration}`,
+          );
+        }
+
+        if (!shouldContinue) {
+          break;
+        }
+
+        if (maxIterations !== undefined && iteration >= maxIterations) {
+          throw new WorkflowExecutionError(
+            `While step ${config.id} exceeded maximum iterations of ${maxIterations}`,
+          );
+        }
+
+        if (args.signal.aborted) {
+          throw args.signal.reason ?? new WorkflowAbortError();
+        }
+
+        const bodyArgs: StepHandlerArgs<
+          WhileLoopState<Input, BodyOutput>,
+          Meta,
+          RootInput
+        > = {
+          context: args.context,
+          signal: args.signal,
+          input: loopState,
+        };
+
+        try {
+          const { output } = await config.body.execute(bodyArgs);
+          lastOutput = output;
+          outputs.push(output);
+        } catch (error) {
+          throw new WorkflowExecutionError(
+            `While step ${config.id} failed while executing body at iteration ${iteration}`,
+            error,
+          );
+        }
+
+        iteration += 1;
+      }
+
+      if (config.collect) {
+        return (await config.collect(outputs)) as WhileStepOutput<
+          BodyOutput,
+          Collect
+        >;
+      }
+
+      return lastOutput as WhileStepOutput<BodyOutput, Collect>;
+    },
+  });

--- a/packages/docs/src/content/docs/core/workflows/boucles.mdx
+++ b/packages/docs/src/content/docs/core/workflows/boucles.mdx
@@ -1,0 +1,68 @@
+---
+title: Boucles while
+description: Répétez des étapes tant qu'une condition reste vraie.
+sidebar:
+  order: 5
+---
+
+`createWhileStep` encapsule une boucle `while` dans un seul nœud de workflow. Vous fournissez un step `condition` (qui renvoie un booléen) et un step `body` (qui produit la sortie de chaque itération). Les deux steps reçoivent un `WhileLoopState` contenant l'entrée initiale, l'index courant et la dernière sortie calculée.
+
+## Exemple : polling d'un job externe
+
+Le fragment suivant interroge une API jusqu'à ce qu'un job passe à l'état `done`. La dernière réponse du corps est renvoyée par défaut, mais vous pouvez agréger toutes les sorties via l'option `collect`.
+
+```ts
+import {
+  createStep,
+  createWhileStep,
+  type WhileLoopState,
+} from "@ai_kit/core";
+
+interface PollInput {
+  jobId: string;
+  maxAttempts: number;
+}
+
+interface PollResponse {
+  status: "pending" | "done" | "failed";
+  payload?: unknown;
+}
+
+const checkStatus = createStep<WhileLoopState<PollInput, PollResponse>, boolean>({
+  id: "check-status",
+  description: "Arrête la boucle quand le job est résolu",
+  handler: async ({ input, signal }) => {
+    if (signal.aborted) throw new Error("Polling annulé");
+    if (input.iteration >= input.initialInput.maxAttempts) {
+      return false;
+    }
+
+    const last = input.lastOutput;
+    return last?.status !== "done" && last?.status !== "failed";
+  },
+});
+
+const fetchStatus = createStep<WhileLoopState<PollInput, PollResponse>, PollResponse>({
+  id: "fetch-status",
+  handler: async ({ input }) => {
+    const response = await fetch(`https://api.example.com/jobs/${input.initialInput.jobId}`);
+    return (await response.json()) as PollResponse;
+  },
+});
+
+export const waitForJob = createWhileStep<PollInput, PollResponse, typeof checkStatus, typeof fetchStatus>({
+  id: "wait-for-job",
+  description: "Boucle jusqu'à la complétion d'un job externe",
+  condition: checkStatus,
+  body: fetchStatus,
+  collect: (responses) => responses.at(-1),
+});
+```
+
+## Points clés
+
+- `maxIterations` force une limite dure et lève `WorkflowExecutionError` si elle est dépassée.
+- L'option `collect` agrège toutes les sorties (par défaut, la dernière sortie du corps est renvoyée).
+- Le `AbortSignal` partagé est vérifié à chaque itération pour interrompre rapidement la boucle.
+
+Combinez `createWhileStep` avec des steps parallèles ou conditionnels pour bâtir des pipelines dynamiques qui restent lisibles.

--- a/packages/docs/src/content/docs/core/workflows/index.mdx
+++ b/packages/docs/src/content/docs/core/workflows/index.mdx
@@ -19,6 +19,7 @@ Les workflows d'AI Kit orchestrent des suites d'étapes typées inspirées de Ma
 - [`Introduction`](./introduction) : installez le package, créez vos premières étapes et exécutez un workflow complet.
 - [`Étapes humaines`](./etapes-humaines) : mettez un humain dans la boucle et gérez le cycle `request → resume`.
 - [`Parallèle & foreach`](./parallele-et-foreach) : mappez vos données avec contrôle de la concurrence et combinez des tâches en parallèle.
+- [`Boucles while`](./boucles) : répétez un step tant qu'une condition reste vraie et agrégez les sorties.
 - [`Branches conditionnelles`](./branches-conditionnelles) : faites bifurquer l'exécution selon vos règles métier.
 
 ## Concepts clés


### PR DESCRIPTION
## Summary
- add a `createWhileStep` helper that loops over condition/body steps with optional collectors and iteration guards
- add vitest coverage for the new while step behavior and abort/max iteration handling
- document while loops in the workflows guide and link it from the overview

## Testing
- pnpm --filter @ai_kit/core test

------
https://chatgpt.com/codex/tasks/task_b_68e05e0ed00c832581e27bb356af401e