### PR TITLE
Restore Agents and Workflows sections in sidebar

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -32,6 +32,18 @@ export default defineConfig({
                                         translations: { en: 'Core' },
                                         items: [
                                                 {
+                                                        label: 'Agents',
+                                                        translations: { en: 'Agents' },
+                                                        link: '/core/agents/',
+                                                        autogenerate: { directory: 'core/agents' },
+                                                },
+                                                {
+                                                        label: 'Workflows',
+                                                        translations: { en: 'Workflows' },
+                                                        link: '/core/workflows/',
+                                                        autogenerate: { directory: 'core/workflows' },
+                                                },
+                                                {
                                                         label: 'Télémétrie Langfuse',
                                                         translations: { en: 'Langfuse telemetry' },
                                                         link: '/core/telemetry/',


### PR DESCRIPTION
## Summary
- add Agents and Workflows groups back to the Core sidebar with localized labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe975d09d08325b081aaf321bc6797