### PR TITLE
Add list endpoints for ServerKit agents and workflows

### DIFF
--- a/packages/mintlify-docs/en/server/index.mdx
+++ b/packages/mintlify-docs/en/server/index.mdx
@@ -45,8 +45,10 @@ The server listens on `HOST` (default `0.0.0.0`) and `PORT` (default `8787`). Ag
 
 | Route | Description |
 | --- | --- |
+| `GET /api/agents` | Lists every agent registered in the server configuration. |
 | `POST /api/agents/:id/generate` | Executes `Agent.generate` once and returns the full result. |
 | `POST /api/agents/:id/stream` | Streams `Agent.stream` via SSE or `DataStreamResponse`. |
+| `GET /api/workflows` | Lists every workflow registered in the server configuration. |
 | `POST /api/workflows/:id/run` | Starts a workflow run and returns `{ runId, ...result }`. |
 | `POST /api/workflows/:id/stream` | Streams every `WorkflowEvent` plus the final status via SSE. |
 | `POST /api/workflows/:id/runs/:runId/resume` | Resumes a suspended run with human input. |

--- a/packages/mintlify-docs/fr/server/index.mdx
+++ b/packages/mintlify-docs/fr/server/index.mdx
@@ -45,8 +45,10 @@ Par défaut, le serveur écoute sur `0.0.0.0` et le port `PORT` (ou 8787). Les i
 
 | Route | Description |
 | --- | --- |
+| `GET /api/agents` | Liste tous les agents déclarés dans la configuration du serveur. |
 | `POST /api/agents/:id/generate` | Exécute `Agent.generate` une fois et retourne la réponse complète. |
 | `POST /api/agents/:id/stream` | Diffuse `Agent.stream` via SSE ou l’API `DataStreamResponse` fournie par `ai`. |
+| `GET /api/workflows` | Liste tous les workflows déclarés dans la configuration du serveur. |
 | `POST /api/workflows/:id/run` | Démarre un run et renvoie son `runId` + l’état final (ou `waiting_human`). |
 | `POST /api/workflows/:id/stream` | Diffuse chaque `WorkflowEvent` et l’état final via SSE. |
 | `POST /api/workflows/:id/runs/:runId/resume` | Reprend un run suspendu avec des données humaines. |

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -30,8 +30,10 @@ await server.listen({ port: 8787 });
 
 The server registers the following endpoints:
 
+- `GET /api/agents` — list registered agents.
 - `POST /api/agents/:id/generate` — synchronously invoke `Agent.generate`.
 - `POST /api/agents/:id/stream` — stream the result of `Agent.stream`.
+- `GET /api/workflows` — list registered workflows.
 - `POST /api/workflows/:id/run` — execute a workflow to completion.
 - `POST /api/workflows/:id/stream` — stream workflow events (Server-Sent Events).
 - `POST /api/workflows/:id/runs/:runId/resume` — resume a suspended workflow run that awaits human input.

--- a/packages/server/src/ServerKit.ts
+++ b/packages/server/src/ServerKit.ts
@@ -153,6 +153,14 @@ export class ServerKit {
   }
 
   private registerRoutes() {
+    this.app.get("/api/agents", c => {
+      return c.json({ agents: this.listAgents() });
+    });
+
+    this.app.get("/api/workflows", c => {
+      return c.json({ workflows: this.listWorkflows() });
+    });
+
     this.app.post("/api/agents/:id/generate", async c => {
       const agent = this.getAgentOrThrow(c);
       const payload = await this.parseJsonBody(c);
@@ -410,6 +418,22 @@ export class ServerKit {
     }
 
     return result.data as ResumePayload;
+  }
+
+  private listAgents() {
+    return Array.from(this.agents.entries()).map(([id, agent]) => ({
+      id,
+      name: agent.name,
+      instructions: agent.instructions,
+    }));
+  }
+
+  private listWorkflows() {
+    return Array.from(this.workflows.entries()).map(([id, workflow]) => ({
+      id,
+      workflowId: workflow.id,
+      description: workflow.description,
+    }));
   }
 
   private storeRun(workflowId: string, run: AnyWorkflowRun) {

--- a/packages/server/src/__tests__/server.test.ts
+++ b/packages/server/src/__tests__/server.test.ts
@@ -74,6 +74,30 @@ describe("ServerKit", () => {
     await expect(response.json()).resolves.toEqual({ message: "ok" });
   });
 
+  it("lists registered agents", async () => {
+    const agent = {
+      name: "Demo Agent",
+      instructions: "Be helpful",
+      generate: vi.fn(),
+      stream: vi.fn(),
+    } as unknown as Agent;
+
+    const server = new ServerKit({ agents: { demo: agent } });
+
+    const response = await server.app.request("/api/agents");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      agents: [
+        {
+          id: "demo",
+          name: "Demo Agent",
+          instructions: "Be helpful",
+        },
+      ],
+    });
+  });
+
   it("returns 404 for unknown workflows", async () => {
     const server = new ServerKit();
 
@@ -120,6 +144,29 @@ describe("ServerKit", () => {
 
     expect(run.start).toHaveBeenCalled();
     expect(run.lastStartOptions?.inputData).toEqual({ foo: "bar" });
+  });
+
+  it("lists registered workflows", async () => {
+    const workflow = {
+      id: "workflow-demo",
+      description: "Demo workflow",
+      createRun: vi.fn(),
+    } as unknown as Workflow<any, any, Record<string, unknown>>;
+
+    const server = new ServerKit({ workflows: { demo: workflow } });
+
+    const response = await server.app.request("/api/workflows");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      workflows: [
+        {
+          id: "demo",
+          workflowId: "workflow-demo",
+          description: "Demo workflow",
+        },
+      ],
+    });
   });
 
   it("streams workflow events and final result", async () => {
@@ -242,7 +289,9 @@ describe("ServerKit", () => {
       openapi: "3.0.3",
       info: expect.objectContaining({ title: "AI Kit API" }),
       paths: expect.objectContaining({
+        "/api/agents": expect.any(Object),
         "/api/agents/{id}/generate": expect.any(Object),
+        "/api/workflows": expect.any(Object),
       }),
     });
 

--- a/packages/server/src/swagger.ts
+++ b/packages/server/src/swagger.ts
@@ -58,6 +58,70 @@ const agentInvocationSchema: OpenAPIV3.SchemaObject = {
   ],
 };
 
+const agentSummarySchema: OpenAPIV3.SchemaObject = {
+  type: "object",
+  required: ["id"],
+  properties: {
+    id: {
+      type: "string",
+      description: "Identifier used to address the agent via the API.",
+    },
+    name: {
+      type: "string",
+      description: "Human-friendly agent name configured at creation time.",
+    },
+    instructions: {
+      type: "string",
+      description: "System instructions associated with the agent, when provided.",
+    },
+  },
+  additionalProperties: false,
+};
+
+const workflowSummarySchema: OpenAPIV3.SchemaObject = {
+  type: "object",
+  required: ["id", "workflowId"],
+  properties: {
+    id: {
+      type: "string",
+      description: "Identifier used to address the workflow via the API.",
+    },
+    workflowId: {
+      type: "string",
+      description: "Internal workflow identifier declared during creation.",
+    },
+    description: {
+      type: "string",
+      description: "Optional workflow description configured at creation time.",
+    },
+  },
+  additionalProperties: false,
+};
+
+const agentListResponseSchema: OpenAPIV3.SchemaObject = {
+  type: "object",
+  required: ["agents"],
+  properties: {
+    agents: {
+      type: "array",
+      items: { $ref: "#/components/schemas/AgentSummary" },
+    },
+  },
+  additionalProperties: false,
+};
+
+const workflowListResponseSchema: OpenAPIV3.SchemaObject = {
+  type: "object",
+  required: ["workflows"],
+  properties: {
+    workflows: {
+      type: "array",
+      items: { $ref: "#/components/schemas/WorkflowSummary" },
+    },
+  },
+  additionalProperties: false,
+};
+
 const workflowRunRequestSchema: OpenAPIV3.SchemaObject = {
   type: "object",
   required: ["inputData"],
@@ -189,6 +253,20 @@ export function buildOpenAPIDocument(config: SwaggerDocumentConfig): OpenAPIV3.D
       { name: "Workflows", description: "Manage workflow runs." },
     ],
     paths: {
+      "/api/agents": {
+        get: {
+          tags: ["Agents"],
+          summary: "List all registered agents.",
+          responses: {
+            200: {
+              description: "Collection of available agents.",
+              content: {
+                "application/json": { schema: agentListResponseSchema },
+              },
+            },
+          },
+        },
+      },
       "/api/agents/{id}/generate": {
         post: {
           tags: ["Agents"],
@@ -351,9 +429,27 @@ export function buildOpenAPIDocument(config: SwaggerDocumentConfig): OpenAPIV3.D
           },
         },
       },
+      "/api/workflows": {
+        get: {
+          tags: ["Workflows"],
+          summary: "List all registered workflows.",
+          responses: {
+            200: {
+              description: "Collection of available workflows.",
+              content: {
+                "application/json": { schema: workflowListResponseSchema },
+              },
+            },
+          },
+        },
+      },
     },
     components: {
       schemas: {
+        AgentSummary: agentSummarySchema,
+        WorkflowSummary: workflowSummarySchema,
+        AgentListResponse: agentListResponseSchema,
+        WorkflowListResponse: workflowListResponseSchema,
         AgentInvocation: agentInvocationSchema,
         WorkflowRunRequest: workflowRunRequestSchema,
         WorkflowRunResponse: workflowRunResponseSchema,


### PR DESCRIPTION
## Summary
- add list endpoints for agents and workflows in ServerKit and expose their metadata
- extend the OpenAPI specification and user docs with the new routes
- cover the new handlers with unit tests

## Testing
- pnpm --filter @ai_kit/server test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911dbc67ebc83258dd6597882782775)