### PR TITLE
docs(server): document custom routes and middleware

### DIFF
--- a/packages/mintlify-docs/docs.json
+++ b/packages/mintlify-docs/docs.json
@@ -56,7 +56,8 @@
               {
                 "group": "Serveur",
                 "pages": [
-                  "fr/server/index"
+                  "fr/server/index",
+                  "fr/server/routes-middleware"
                 ]
               },
               {
@@ -145,7 +146,8 @@
               {
                 "group": "Server",
                 "pages": [
-                  "en/server/index"
+                  "en/server/index",
+                  "en/server/custom-routes"
                 ]
               },
               {

--- a/packages/mintlify-docs/en/server/custom-routes.mdx
+++ b/packages/mintlify-docs/en/server/custom-routes.mdx
@@ -1,0 +1,75 @@
+---
+title: "Custom routes & middleware"
+description: "Extend the ServerKit HTTP API with bespoke endpoints and request guards."
+locale: en
+---
+
+ServerKit now mirrors Mastra's developer experience: you can register extra HTTP endpoints alongside the built-in agent and workflow routes, and you can plug middleware at the route or application level.
+
+## Quick start
+
+Use the exported `registerApiRoute` helper to declare an endpoint. Add it to the `server.apiRoutes` array and ServerKit will mount it under the root of your server.
+
+```ts
+import { ServerKit, registerApiRoute } from "@ai_kit/server";
+
+const server = new ServerKit({
+  agents: {},
+  workflows: {},
+  server: {
+    apiRoutes: [
+      registerApiRoute("/healthz", {
+        method: "GET",
+        handler: (c) => c.json({ status: "ok" }),
+      }),
+    ],
+  },
+});
+```
+
+Each route receives the [Hono context](https://hono.dev/api/context) so you can read headers, query parameters, or return any valid response type. The helper also normalizes the route path, preventing duplicate slashes or missing leading `/` characters.
+
+## Accessing ServerKit internals
+
+Within a handler you can reach the `ServerKit` instance via `c.get("serverKit")`, or the underlying Mastra-compatible object via `c.get("mastra")`. This lets you reuse the same agents or workflows that power the default API.
+
+```ts
+registerApiRoute("/workload", {
+  method: "GET",
+  handler: async (c) => {
+    const serverKit = c.get("serverKit");
+    const workflows = await serverKit.runtime.getWorkflows();
+
+    return c.json({
+      workflows,
+      requestedAt: new Date().toISOString(),
+    });
+  },
+});
+```
+
+## Adding middleware
+
+Custom routes can declare middleware at registration time. Use it to enforce authentication, emit logs, or mutate the context before the handler executes.
+
+```ts
+registerApiRoute("/secure-data", {
+  method: "GET",
+  middleware: [
+    async (c, next) => {
+      if (!c.req.header("authorization")) {
+        return c.text("Missing auth", 401);
+      }
+
+      await next();
+    },
+  ],
+  handler: (c) => c.json({ secret: "42" }),
+});
+```
+
+You can still rely on the global `server.middleware` option to run code before every route—including your customs ones. Route-level middleware executes after global middleware but before the handler.
+
+## Testing custom routes
+
+The integration tests in `packages/server/src/__tests__/server.test.ts` demonstrate how to spin up a `ServerKit` instance, hit a custom route, and assert on the JSON payload. Reuse the same approach in your own test suite to cover bespoke endpoints and authentication flows.

--- a/packages/mintlify-docs/fr/server/routes-middleware.mdx
+++ b/packages/mintlify-docs/fr/server/routes-middleware.mdx
@@ -1,0 +1,75 @@
+---
+title: "Routes custom & middleware"
+description: "Étendre l’API HTTP de ServerKit avec des endpoints dédiés et des gardes de requête."
+locale: fr
+---
+
+ServerKit reprend désormais l’expérience Mastra : ajoutez vos propres endpoints HTTP en plus des routes agents/workflows intégrées et branchez du middleware au niveau global ou route par route.
+
+## Démarrage rapide
+
+Utilisez le helper `registerApiRoute` exporté par `@ai_kit/server` pour déclarer une route. Ajoutez-la au tableau `server.apiRoutes` et ServerKit la montera automatiquement à la racine du serveur.
+
+```ts
+import { ServerKit, registerApiRoute } from "@ai_kit/server";
+
+const server = new ServerKit({
+  agents: {},
+  workflows: {},
+  server: {
+    apiRoutes: [
+      registerApiRoute("/healthz", {
+        method: "GET",
+        handler: (c) => c.json({ status: "ok" }),
+      }),
+    ],
+  },
+});
+```
+
+Chaque handler reçoit le [contexte Hono](https://hono.dev/api/context), ce qui vous permet de lire les en-têtes, les paramètres de requête ou de retourner n’importe quel type de réponse. Le helper normalise également le chemin pour éviter les `/` manquants ou en double.
+
+## Accéder aux internes de ServerKit
+
+Depuis un handler vous pouvez récupérer l’instance `ServerKit` via `c.get("serverKit")`, ou l’objet compatible Mastra via `c.get("mastra")`. Pratique pour réutiliser vos agents et workflows existants.
+
+```ts
+registerApiRoute("/workload", {
+  method: "GET",
+  handler: async (c) => {
+    const serverKit = c.get("serverKit");
+    const workflows = await serverKit.runtime.getWorkflows();
+
+    return c.json({
+      workflows,
+      requestedAt: new Date().toISOString(),
+    });
+  },
+});
+```
+
+## Ajouter du middleware
+
+Les routes custom peuvent embarquer leur propre middleware. Servez-vous-en pour imposer une authentification, logger les requêtes ou enrichir le contexte avant le handler.
+
+```ts
+registerApiRoute("/secure-data", {
+  method: "GET",
+  middleware: [
+    async (c, next) => {
+      if (!c.req.header("authorization")) {
+        return c.text("Missing auth", 401);
+      }
+
+      await next();
+    },
+  ],
+  handler: (c) => c.json({ secret: "42" }),
+});
+```
+
+Vous pouvez toujours déclarer des middlewares globaux via `server.middleware`. Ils s’exécutent avant ceux définis directement sur la route, qui eux-mêmes passent la main au handler final.
+
+## Tester vos routes custom
+
+Les tests d’intégration situés dans `packages/server/src/__tests__/server.test.ts` montrent comment lancer un `ServerKit`, appeler une route custom et vérifier le JSON de réponse. Inspirez-vous de ce patron pour sécuriser vos propres endpoints et scénarios d’authentification.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,4 +7,8 @@ export {
   type ServerMiddlewareConfig,
   type ServerRuntimeOptions,
   createServerKit,
+  registerApiRoute,
+  type ApiRouteMethod,
+  type ApiRouteConfig,
+  type ApiRouteDefinition,
 } from "./ServerKit.js";


### PR DESCRIPTION
## Summary
- add a dedicated ServerKit guide for custom routes and middleware in English
- localize the same content for French readers
- surface the new guides in the Mintlify navigation

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69122215b6388325bef50d9e7df4202f)