### PR TITLE
Add manual workflow to run server tests via dispatch

### DIFF
--- a/.github/workflows/manual-server-tests.yml
+++ b/.github/workflows/manual-server-tests.yml
@@ -1,0 +1,35 @@
+name: Manual Server Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to test'
+        required: true
+        default: main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run server tests
+        run: pnpm --filter @ai_kit/server test


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions workflow that allows selecting the branch to test
- configure Node.js and pnpm setup consistent with existing build workflows
- run server package tests with pnpm filter after installing dependencies

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912258e437c83258c38d98a564635bf)