### PR TITLE
chore(server): bump jose to 6.1.1

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -43,6 +43,7 @@
     "@hono/node-server": "^1.13.4",
     "@hono/swagger-ui": "^0.5.2",
     "hono": "^4.10.4",
+    "jose": "^6.1.1",
     "openapi-types": "^12.1.3",
     "zod": "^3.1.12"
   },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ export {
   type ServerMiddleware,
   type ServerMiddlewareConfig,
   type ServerRuntimeOptions,
+  type ServerAuthConfig,
   createServerKit,
   registerApiRoute,
   type ApiRouteMethod,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       hono:
         specifier: ^4.10.4
         version: 4.10.4
+      jose:
+        specifier: ^6.1.1
+        version: 6.1.1
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
@@ -1154,6 +1157,9 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jose@6.1.1:
+    resolution: {integrity: sha512-GWSqjfOPf4cWOkBzw5THBjtGPhXKqYnfRBzh4Ni+ArTrQQ9unvmsA3oFLqaYKoKe5sjWmGu5wVKg9Ft1i+LQfg==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -2584,6 +2590,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jose@6.1.1: {}
 
   joycon@3.1.1: {}
 


### PR DESCRIPTION
## Summary
- upgrade the server package to depend on jose 6.1.1
- refresh the lockfile to capture the new jwt library release

## Testing
- pnpm --filter @ai_kit/server test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691228dd3fe483258576d19abec22693)