### PR TITLE
docs: add server authentication guides

### DIFF
--- a/packages/mintlify-docs/docs.json
+++ b/packages/mintlify-docs/docs.json
@@ -57,6 +57,7 @@
                 "group": "Serveur",
                 "pages": [
                   "fr/server/index",
+                  "fr/server/auth",
                   "fr/server/routes-middleware"
                 ]
               },
@@ -147,6 +148,7 @@
                 "group": "Server",
                 "pages": [
                   "en/server/index",
+                  "en/server/auth",
                   "en/server/custom-routes"
                 ]
               },

--- a/packages/mintlify-docs/en/server/auth.mdx
+++ b/packages/mintlify-docs/en/server/auth.mdx
@@ -1,0 +1,116 @@
+---
+title: "Authentication"
+description: "Protect ServerKit endpoints with bearer tokens or bespoke guards."
+locale: en
+---
+
+ServerKit ships with two complementary layers to secure your HTTP API:
+
+- an opt-in bearer-token guard that validates JSON Web Tokens (JWT) before any built-in route executes;
+- the ability to chain custom [Hono middleware](https://hono.dev/api/middleware) or register bespoke routes with their own protections.
+
+Use the sections below to enable the built-in guard, mint compatible tokens, and combine it with your own access control logic.
+
+## Enabling the bearer guard
+
+Provide a `server.auth` object when instantiating `ServerKit` to require a bearer token on every request. The guard is active as soon as you pass a non-empty `secret`; the `enabled` flag defaults to `true` so you only need to flip it when turning the guard off temporarily.
+
+```ts
+import { ServerKit } from "@ai_kit/server";
+
+const server = new ServerKit({
+  agents: { /* ... */ },
+  workflows: { /* ... */ },
+  server: {
+    auth: {
+      secret: process.env.SERVER_AUTH_SECRET!,
+      // enabled: true, // defaults to true when auth is provided
+    },
+  },
+});
+```
+
+With this configuration:
+
+- requests missing the `Authorization` header receive `401 Missing Authorization header`;
+- headers that do not use the `Bearer` scheme (for example `Basic` or an empty value) receive `401 Authorization header must use the Bearer scheme`;
+- malformed or expired tokens raise `401 Invalid authorization token`.
+
+Set `enabled: false` to keep the configuration around while bypassing the guard, for example in local development.
+
+## Issuing compatible tokens
+
+The guard expects a JWT signed with the shared secret using an HMAC algorithm such as `HS256`. A quick way to mint tokens is with the [`jose`](https://github.com/panva/jose) package that AI Kit already depends on.
+
+```ts
+import { SignJWT } from "jose";
+
+async function createServerToken() {
+  const secret = new TextEncoder().encode(process.env.SERVER_AUTH_SECRET!);
+
+  return await new SignJWT({
+    sub: "user-123",
+    roles: ["support", "admin"],
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("15m")
+    .sign(secret);
+}
+```
+
+Send the token in an `Authorization: Bearer <token>` header when calling any server endpoint (agents, workflows, streaming SSE, custom routes, Swagger, etc.).
+
+## Reading the decoded payload
+
+Once the middleware verifies a token, it stores the raw token and decoded payload on the Hono context under the `auth` key. Any downstream middleware or handler can read it to tailor behaviour to the current principal.
+
+```ts
+const middleware = async (c, next) => {
+  const auth = c.get("auth");
+  if (auth?.payload.roles?.includes("admin")) {
+    await next();
+    return;
+  }
+
+  return c.json({ error: "Forbidden" }, 403);
+};
+```
+
+Use this pattern to implement role-based access control without having to re-parse the token inside each handler.
+
+## Combining with custom strategies
+
+Need API keys, IP allow-lists, or multi-tenant scoping? Chain additional middleware via the `server.middleware` array or directly inside `registerApiRoute`.
+
+```ts
+import { ServerKit, registerApiRoute } from "@ai_kit/server";
+
+const server = new ServerKit({
+  agents: {},
+  workflows: {},
+  server: {
+    auth: { secret: process.env.SERVER_AUTH_SECRET! },
+    middleware: [
+      async (c, next) => {
+        if (c.req.header("x-api-key") !== process.env.PUBLIC_API_KEY) {
+          return c.json({ error: "invalid api key" }, 401);
+        }
+
+        await next();
+      },
+    ],
+    apiRoutes: [
+      registerApiRoute("/tenant-info", {
+        method: "GET",
+        async handler(c) {
+          const { payload } = c.get("auth");
+          return c.json({ tenantId: payload.tenantId });
+        },
+      }),
+    ],
+  },
+});
+```
+
+Global middleware runs before the bearer guard hands control to your handlers, so you can bail out early, enrich the context, or even set additional data for later steps. Custom routes declared through `registerApiRoute` automatically inherit both the bearer guard and the middleware chain, ensuring consistent protection across your API.

--- a/packages/mintlify-docs/en/server/index.mdx
+++ b/packages/mintlify-docs/en/server/index.mdx
@@ -47,6 +47,8 @@ await server.listen({ port: 8787 });
 
 The server listens on `HOST` (default `0.0.0.0`) and `PORT` (default `8787`). Agents and workflows are stored in memory and reused across requests.
 
+> Need to protect the API? Head over to the [Authentication guide](./auth) to enable bearer tokens and custom guards.
+
 ## Exposed endpoints
 
 | Route | Description |

--- a/packages/mintlify-docs/fr/server/auth.mdx
+++ b/packages/mintlify-docs/fr/server/auth.mdx
@@ -1,0 +1,116 @@
+---
+title: "Authentification"
+description: "Sécuriser les endpoints ServerKit avec des tokens bearer ou vos propres gardes."
+locale: fr
+---
+
+ServerKit propose deux leviers complémentaires pour protéger votre API HTTP :
+
+- un garde bearer optionnel qui vérifie des JSON Web Tokens (JWT) avant d’exécuter les routes intégrées ;
+- la possibilité d’enchaîner du [middleware Hono](https://hono.dev/api/middleware) ou de déclarer des routes sur mesure avec leurs propres contrôles.
+
+Les sections ci-dessous expliquent comment activer le garde intégré, émettre des tokens compatibles et le combiner avec vos règles d’accès.
+
+## Activer le garde bearer
+
+Passez un objet `server.auth` lors de l’instanciation de `ServerKit` pour exiger un token bearer sur chaque requête. Le garde s’active dès que vous fournissez un `secret` non vide ; le champ `enabled` vaut `true` par défaut, vous ne devez le préciser que pour désactiver temporairement la vérification.
+
+```ts
+import { ServerKit } from "@ai_kit/server";
+
+const server = new ServerKit({
+  agents: { /* ... */ },
+  workflows: { /* ... */ },
+  server: {
+    auth: {
+      secret: process.env.SERVER_AUTH_SECRET!,
+      // enabled: true, // activé par défaut dès que auth est défini
+    },
+  },
+});
+```
+
+Avec cette configuration :
+
+- les requêtes sans en-tête `Authorization` reçoivent `401 Missing Authorization header` ;
+- un schéma différent de `Bearer` (ex. `Basic` ou une valeur vide) entraîne `401 Authorization header must use the Bearer scheme` ;
+- les tokens expirés ou invalides produisent `401 Invalid authorization token`.
+
+Positionnez `enabled: false` pour conserver la configuration tout en court-circuitant le garde (utile en développement local).
+
+## Émettre des tokens compatibles
+
+Le garde attend un JWT signé avec le secret partagé via un algorithme HMAC comme `HS256`. Vous pouvez générer ces tokens avec [`jose`](https://github.com/panva/jose), déjà inclus dans les dépendances AI Kit.
+
+```ts
+import { SignJWT } from "jose";
+
+async function createServerToken() {
+  const secret = new TextEncoder().encode(process.env.SERVER_AUTH_SECRET!);
+
+  return await new SignJWT({
+    sub: "user-123",
+    roles: ["support", "admin"],
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("15m")
+    .sign(secret);
+}
+```
+
+Envoyez ensuite le token dans l’en-tête `Authorization: Bearer <token>` sur l’ensemble des endpoints (agents, workflows, SSE, routes custom, Swagger, etc.).
+
+## Lire la charge utile décodée
+
+Après vérification, le middleware stocke le token brut et sa charge utile décodée dans le contexte Hono (`c.set("auth", { token, payload })`). Tout middleware ou handler en aval peut les lire pour adapter le comportement à l’utilisateur courant.
+
+```ts
+const middleware = async (c, next) => {
+  const auth = c.get("auth");
+  if (auth?.payload.roles?.includes("admin")) {
+    await next();
+    return;
+  }
+
+  return c.json({ error: "Forbidden" }, 403);
+};
+```
+
+Ce pattern facilite l’implémentation d’un contrôle d’accès basé sur les rôles sans devoir re-parser le token dans chaque handler.
+
+## Combiner avec vos stratégies
+
+Besoin de clés API, de listes blanches IP ou de découper par tenant ? Chaînez du middleware supplémentaire via `server.middleware` ou directement dans `registerApiRoute`.
+
+```ts
+import { ServerKit, registerApiRoute } from "@ai_kit/server";
+
+const server = new ServerKit({
+  agents: {},
+  workflows: {},
+  server: {
+    auth: { secret: process.env.SERVER_AUTH_SECRET! },
+    middleware: [
+      async (c, next) => {
+        if (c.req.header("x-api-key") !== process.env.PUBLIC_API_KEY) {
+          return c.json({ error: "invalid api key" }, 401);
+        }
+
+        await next();
+      },
+    ],
+    apiRoutes: [
+      registerApiRoute("/tenant-info", {
+        method: "GET",
+        async handler(c) {
+          const { payload } = c.get("auth");
+          return c.json({ tenantId: payload.tenantId });
+        },
+      }),
+    ],
+  },
+});
+```
+
+Le middleware global s’exécute avant que le garde bearer ne confie la main au handler, ce qui vous permet d’interrompre la requête, d’enrichir le contexte ou de stocker des données complémentaires. Les routes déclarées via `registerApiRoute` héritent automatiquement du garde bearer et du chaînage de middleware pour une protection homogène sur toute votre API.

--- a/packages/mintlify-docs/fr/server/index.mdx
+++ b/packages/mintlify-docs/fr/server/index.mdx
@@ -47,6 +47,8 @@ await server.listen({ port: 8787 });
 
 Par défaut, le serveur écoute sur `0.0.0.0` et le port `PORT` (ou 8787). Les instances d’agent et de workflow sont conservées en mémoire et réutilisées à chaque requête.
 
+> Besoin de verrouiller l’API ? Consultez le guide [Authentification](./auth) pour activer les tokens bearer et vos gardes personnalisés.
+
 ## Endpoints exposés
 
 | Route | Description |


### PR DESCRIPTION
## Summary
- add dedicated ServerKit authentication guides in English and French
- link the new guide from the server landing pages and navigation for both locales

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69122f29463c8325bdd37dbbe3fdcf62)