### PR TITLE
feat: add client kit package

### DIFF
--- a/.github/workflows/release-client-kit.yml
+++ b/.github/workflows/release-client-kit.yml
@@ -1,0 +1,83 @@
+name: Publish Client Kit
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'packages/client-kit/package.json'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@ai_kit'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+
+      - name: Get package version
+        id: package
+        run: |
+          VERSION=$(cd packages/client-kit && node -p "require('./package.json').version")
+          PACKAGE_NAME=$(cd packages/client-kit && node -p "require('./package.json').name")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+          echo "Package: $PACKAGE_NAME@$VERSION"
+
+      - name: Check if version exists on NPM
+        id: npm-check
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd packages/client-kit
+          if npm view ${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }} version 2>/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Version ${{ steps.package.outputs.version }} already exists on NPM"
+            exit 1
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Version ${{ steps.package.outputs.version }} does not exist on NPM"
+          fi
+
+      - name: Install dependencies
+        run: |
+          cd packages/client-kit
+          pnpm install
+
+      - name: Build package
+        run: |
+          cd packages/client-kit
+          pnpm build
+
+      - name: Publish to NPM
+        run: |
+          cd packages/client-kit
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.package.outputs.version }}
+          name: AI KIT client - Release v${{ steps.package.outputs.version }}
+          body: |
+            ## Changes
+
+            Package ${{ steps.package.outputs.name }} has been updated to version ${{ steps.package.outputs.version }}.
+          draft: false
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -32,6 +32,48 @@ npm i @ai_kit/server
 
 Consultez la page npm pour les exemples de configuration détaillés et les options d’exécution.
 
+## Client HTTP
+
+Pour consommer facilement une instance Server Kit à distance, utilisez le package [`@ai_kit/client-kit`](https://www.npmjs.com/package/@ai_kit/client-kit). Il gère l’URL de base, les en-têtes communs et l’hydratation du contexte d’exécution.
+
+```bash
+npm i @ai_kit/client-kit
+```
+
+```ts
+import { ClientKit } from "@ai_kit/client-kit";
+
+const client = new ClientKit({
+  baseUrl: "https://agents.internal.aidalinfo.fr",
+  headers: {
+    Authorization: `Bearer ${process.env.SERVER_TOKEN}`,
+  },
+  runtime: {
+    metadata: { tenant: "aidalinfo" },
+    ctx: { locale: "fr-FR" },
+  },
+});
+
+const supportAgent = await client.getAgent("support");
+const response = await client.generateAgent("support", {
+  prompt: "Quelles sont les nouveautés de cette semaine ?",
+});
+
+const workflowResult = await client.runWorkflow("enrich-contact", {
+  inputData: { contactId: "42" },
+  metadata: { requestId: "run-123" },
+});
+
+if (workflowResult.status === "waiting_human" && workflowResult.pendingHuman) {
+  await client.resumeWorkflow("enrich-contact", workflowResult.runId, {
+    stepId: workflowResult.pendingHuman.stepId,
+    data: { approved: true },
+  });
+}
+```
+
+Le client fournit également `resumeWorkflow` pour répondre à une étape humaine et fusionne automatiquement les métadonnées/contexts par défaut avec celles passées à l’appel.
+
 ## Utilisation rapide
 
 ### Créer un agent

--- a/packages/client-kit/README.md
+++ b/packages/client-kit/README.md
@@ -1,0 +1,51 @@
+# @ai_kit/client-kit
+
+Client léger pour interagir avec un serveur AI Kit. Il standardise les appels HTTP et vous évite de manipuler manuellement les URLs ou les en-têtes.
+
+## Installation
+
+```bash
+npm install @ai_kit/client-kit
+```
+
+## Utilisation
+
+```ts
+import { ClientKit } from "@ai_kit/client-kit";
+
+const client = new ClientKit({
+  baseUrl: "https://agents.internal.aidalinfo.fr",
+  headers: { Authorization: `Bearer ${process.env.SERVER_TOKEN}` },
+  runtime: {
+    metadata: { tenant: "aidalinfo" },
+    ctx: { locale: "fr-FR" },
+  },
+});
+
+const agent = await client.getAgent("support");
+const answer = await client.generateAgent("support", {
+  prompt: "Donne-moi le résumé de la dernière release.",
+});
+
+const run = await client.runWorkflow("enrich-contact", {
+  inputData: { contactId: "123" },
+  metadata: { requestId: "run_abc" },
+});
+
+if (run.status === "waiting_human" && run.pendingHuman) {
+  await client.resumeWorkflow("enrich-contact", run.runId, {
+    stepId: run.pendingHuman.stepId,
+    data: { approved: true },
+  });
+}
+```
+
+## API
+
+- `listAgents()` / `getAgent(id)`
+- `generateAgent(id, payload)`
+- `listWorkflows()` / `getWorkflow(id)`
+- `runWorkflow(id, payload)`
+- `resumeWorkflow(id, runId, payload)`
+
+Les métadonnées et le contexte (`ctx`) définis dans `runtime` sont fusionnés automatiquement avec ceux fournis à l’appel.

--- a/packages/client-kit/package.json
+++ b/packages/client-kit/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@ai_kit/client-kit",
+  "version": "0.1.0",
+  "description": "Lightweight HTTP client for interacting with AI Kit servers",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "pnpm run clean && tsc -p tsconfig.build.json",
+    "prepare": "pnpm run build",
+    "test": "vitest run"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "ai",
+    "agent",
+    "workflow",
+    "client"
+  ],
+  "license": "MIT",
+  "packageManager": "pnpm@10.15.0",
+  "dependencies": {
+    "@ai_kit/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.0",
+    "typescript": "^5.9.2",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/client-kit/src/ClientKit.ts
+++ b/packages/client-kit/src/ClientKit.ts
@@ -1,0 +1,396 @@
+import type {
+  AgentGenerateResult,
+  WorkflowRunOptions,
+  WorkflowRunResult,
+} from "@ai_kit/core";
+
+export interface ClientKitOptions {
+  baseUrl?: string;
+  headers?: HeadersInit;
+  fetch?: typeof fetch;
+  runtime?: DefaultRuntimeContext;
+}
+
+export interface DefaultRuntimeContext {
+  metadata?: Record<string, unknown>;
+  ctx?: Record<string, unknown>;
+}
+
+export interface RequestOptions {
+  headers?: HeadersInit;
+  signal?: AbortSignal;
+}
+
+export interface AgentSummary {
+  id: string;
+  name: string;
+  instructions?: string;
+}
+
+export interface WorkflowSummary {
+  id: string;
+  workflowId: string;
+  description?: string;
+}
+
+export type AgentGeneratePayload =
+  | ({ prompt: string; messages?: never } & Record<string, unknown>)
+  | ({ messages: unknown; prompt?: never } & Record<string, unknown>)
+  | ({ prompt: string; messages: unknown } & Record<string, unknown>);
+
+export interface WorkflowRunPayload<
+  Input,
+  Meta extends Record<string, unknown> = Record<string, unknown>,
+  Ctx extends Record<string, unknown> = Record<string, unknown>,
+> {
+  inputData: Input;
+  metadata?: Meta;
+  ctx?: Ctx;
+  telemetry?: WorkflowRunOptions<Input, Meta, Ctx>["telemetry"];
+}
+
+export interface ResumeWorkflowPayload {
+  stepId: string;
+  data: unknown;
+}
+
+export type WorkflowRunResponse<
+  Output,
+  Meta extends Record<string, unknown>,
+  Ctx extends Record<string, unknown>,
+> = WorkflowRunResult<Output, Meta, Ctx> & { runId: string };
+
+export class ClientKitError extends Error {
+  readonly status: number;
+  readonly details?: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.name = "ClientKitError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+function mergeRecords<T extends Record<string, unknown> | undefined>(
+  base: T,
+  override: T,
+): T {
+  if (!base && !override) {
+    return undefined as T;
+  }
+
+  if (!base) {
+    return override;
+  }
+
+  if (!override) {
+    return base;
+  }
+
+  return { ...base, ...override } as T;
+}
+
+function ensureAgentPayload(payload: AgentGeneratePayload) {
+  if (!payload || typeof payload !== "object") {
+    throw new ClientKitError("Agent payload must be an object", 400);
+  }
+
+  const hasPrompt = "prompt" in payload && payload.prompt !== undefined;
+  const hasMessages = "messages" in payload && payload.messages !== undefined;
+
+  if (!hasPrompt && !hasMessages) {
+    throw new ClientKitError(
+      "Agent payload must include a prompt or messages field",
+      400,
+    );
+  }
+}
+
+export class ClientKit {
+  private readonly baseUrl: URL;
+  private readonly defaultHeaders: Headers;
+  private readonly fetchImpl: typeof fetch;
+  private readonly runtimeDefaults: DefaultRuntimeContext;
+
+  constructor(options: ClientKitOptions = {}) {
+    const baseUrl = options.baseUrl ?? "http://localhost:3000";
+    this.baseUrl = new URL(baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
+    this.defaultHeaders = this.toHeaders(options.headers);
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+
+    if (typeof this.fetchImpl !== "function") {
+      throw new Error("ClientKit requires a fetch implementation");
+    }
+
+    this.runtimeDefaults = options.runtime ?? {};
+  }
+
+  async listAgents(options?: RequestOptions): Promise<AgentSummary[]> {
+    const { agents } = await this.requestJson<{ agents: AgentSummary[] }>(
+      "/api/agents",
+      {
+        method: "GET",
+        headers: options?.headers,
+        signal: options?.signal,
+      },
+    );
+
+    return agents;
+  }
+
+  async getAgent(id: string, options?: RequestOptions): Promise<AgentSummary> {
+    const agents = await this.listAgents(options);
+    const agent = agents.find(entry => entry.id === id);
+
+    if (!agent) {
+      throw new ClientKitError(`Agent ${id} not found`, 404);
+    }
+
+    return agent;
+  }
+
+  async generateAgent<
+    OUTPUT = unknown,
+    PAYLOAD extends AgentGeneratePayload = AgentGeneratePayload,
+  >(
+    id: string,
+    payload: PAYLOAD,
+    options?: RequestOptions,
+  ): Promise<AgentGenerateResult<OUTPUT>> {
+    ensureAgentPayload(payload);
+
+    return this.requestJson<AgentGenerateResult<OUTPUT>>(
+      `/api/agents/${encodeURIComponent(id)}/generate`,
+      {
+        method: "POST",
+        body: payload,
+        headers: options?.headers,
+        signal: options?.signal,
+      },
+    );
+  }
+
+  async listWorkflows(options?: RequestOptions): Promise<WorkflowSummary[]> {
+    const { workflows } = await this.requestJson<{ workflows: WorkflowSummary[] }>(
+      "/api/workflows",
+      {
+        method: "GET",
+        headers: options?.headers,
+        signal: options?.signal,
+      },
+    );
+
+    return workflows;
+  }
+
+  async getWorkflow(
+    id: string,
+    options?: RequestOptions,
+  ): Promise<WorkflowSummary> {
+    const workflows = await this.listWorkflows(options);
+    const workflow = workflows.find(entry => entry.id === id);
+
+    if (!workflow) {
+      throw new ClientKitError(`Workflow ${id} not found`, 404);
+    }
+
+    return workflow;
+  }
+
+  async runWorkflow<
+    Input,
+    Output = unknown,
+    Meta extends Record<string, unknown> = Record<string, unknown>,
+    Ctx extends Record<string, unknown> = Record<string, unknown>,
+  >(
+    id: string,
+    payload: WorkflowRunPayload<Input, Meta, Ctx>,
+    options?: RequestOptions,
+  ): Promise<WorkflowRunResponse<Output, Meta, Ctx>> {
+    if (!payload || typeof payload !== "object") {
+      throw new ClientKitError("Workflow payload must be an object", 400);
+    }
+
+    if (!("inputData" in payload)) {
+      throw new ClientKitError(
+        "Workflow payload must include an inputData field",
+        400,
+      );
+    }
+
+    const body = this.buildWorkflowBody(payload);
+
+    return this.requestJson<WorkflowRunResponse<Output, Meta, Ctx>>(
+      `/api/workflows/${encodeURIComponent(id)}/run`,
+      {
+        method: "POST",
+        body,
+        headers: options?.headers,
+        signal: options?.signal,
+      },
+    );
+  }
+
+  async resumeWorkflow<
+    Output = unknown,
+    Meta extends Record<string, unknown> = Record<string, unknown>,
+    Ctx extends Record<string, unknown> = Record<string, unknown>,
+  >(
+    id: string,
+    runId: string,
+    payload: ResumeWorkflowPayload,
+    options?: RequestOptions,
+  ): Promise<WorkflowRunResponse<Output, Meta, Ctx>> {
+    if (!payload || typeof payload !== "object") {
+      throw new ClientKitError("Resume payload must be an object", 400);
+    }
+
+    if (typeof payload.stepId !== "string" || payload.stepId.length === 0) {
+      throw new ClientKitError("Resume payload must include a stepId", 400);
+    }
+
+    return this.requestJson<WorkflowRunResponse<Output, Meta, Ctx>>(
+      `/api/workflows/${encodeURIComponent(id)}/runs/${encodeURIComponent(runId)}/resume`,
+      {
+        method: "POST",
+        body: payload,
+        headers: options?.headers,
+        signal: options?.signal,
+      },
+    );
+  }
+
+  private buildWorkflowBody<
+    Input,
+    Meta extends Record<string, unknown>,
+    Ctx extends Record<string, unknown>,
+  >(payload: WorkflowRunPayload<Input, Meta, Ctx>) {
+    const metadata = mergeRecords(
+      this.runtimeDefaults.metadata,
+      payload.metadata,
+    );
+
+    const ctx = mergeRecords(this.runtimeDefaults.ctx, payload.ctx);
+
+    const body: Record<string, unknown> = {
+      inputData: payload.inputData,
+    };
+
+    if (metadata !== undefined) {
+      body.metadata = metadata;
+    }
+
+    if (ctx !== undefined) {
+      body.ctx = ctx;
+    }
+
+    if (payload.telemetry !== undefined) {
+      body.telemetry = payload.telemetry;
+    }
+
+    return body;
+  }
+
+  private toHeaders(init?: HeadersInit): Headers {
+    const headers = new Headers();
+    if (init) {
+      const normalized = new Headers(init);
+      normalized.forEach((value, key) => {
+        headers.set(key, value);
+      });
+    }
+    return headers;
+  }
+
+  private mergeHeaders(...inits: (HeadersInit | undefined)[]): Headers {
+    const headers = new Headers(this.defaultHeaders);
+    for (const init of inits) {
+      if (!init) {
+        continue;
+      }
+      const normalized = new Headers(init);
+      normalized.forEach((value, key) => {
+        headers.set(key, value);
+      });
+    }
+    return headers;
+  }
+
+  private resolveUrl(path: string): string {
+    const relative = path.startsWith("/") ? path.slice(1) : path;
+    return new URL(relative, this.baseUrl).toString();
+  }
+
+  private async requestJson<T>(
+    path: string,
+    init: {
+      method?: string;
+      body?: unknown;
+      headers?: HeadersInit;
+      signal?: AbortSignal;
+    } = {},
+  ): Promise<T> {
+    const headers = this.mergeHeaders(init.headers);
+
+    if (init.body !== undefined && !headers.has("content-type")) {
+      headers.set("content-type", "application/json");
+    }
+
+    if (!headers.has("accept")) {
+      headers.set("accept", "application/json");
+    }
+
+    const response = await this.fetchImpl(this.resolveUrl(path), {
+      method: init.method ?? (init.body === undefined ? "GET" : "POST"),
+      headers,
+      body:
+        init.body === undefined
+          ? undefined
+          : JSON.stringify(init.body, (_key, value) =>
+              value instanceof Map ? Object.fromEntries(value) : value,
+            ),
+      signal: init.signal,
+    });
+
+    if (!response.ok) {
+      let details: unknown;
+      const contentType = response.headers.get("content-type");
+      if (contentType && contentType.includes("application/json")) {
+        try {
+          details = await response.json();
+        } catch {
+          details = undefined;
+        }
+      } else {
+        try {
+          details = await response.text();
+        } catch {
+          details = undefined;
+        }
+      }
+
+      throw new ClientKitError(
+        `Request to ${path} failed with status ${response.status}`,
+        response.status,
+        details,
+      );
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    const contentType = response.headers.get("content-type");
+    if (!contentType || !contentType.includes("application/json")) {
+      throw new ClientKitError(
+        `Expected JSON response from ${path} but received ${contentType ?? "unknown content type"}`,
+        response.status,
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+}
+
+export default ClientKit;

--- a/packages/client-kit/src/__tests__/ClientKit.test.ts
+++ b/packages/client-kit/src/__tests__/ClientKit.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+
+import ClientKit, {
+  ClientKitError,
+  type AgentSummary,
+  type WorkflowSummary,
+} from "../ClientKit.js";
+
+function createJsonResponse(data: unknown, status = 200) {
+  const headers = new Headers({ "content-type": "application/json" });
+  return new Response(JSON.stringify(data), { status, headers });
+}
+
+describe("ClientKit", () => {
+  const baseUrl = "https://example.com";
+
+  it("lists agents", async () => {
+    const agents: AgentSummary[] = [
+      { id: "assistant", name: "Assistant" },
+    ];
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({ agents }),
+    );
+    const client = new ClientKit({ baseUrl, fetch: fetchMock });
+
+    const result = await client.listAgents();
+
+    expect(result).toEqual(agents);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/api/agents",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    );
+  });
+
+  it("throws when an agent is not found", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({ agents: [] }),
+    );
+    const client = new ClientKit({ baseUrl, fetch: fetchMock });
+
+    await expect(client.getAgent("unknown")).rejects.toThrowError(
+      ClientKitError,
+    );
+  });
+
+  it("validates agent payloads", async () => {
+    const fetchMock = vi.fn();
+    const client = new ClientKit({ baseUrl, fetch: fetchMock });
+
+    await expect(
+      client.generateAgent("assistant", {} as never),
+    ).rejects.toThrowError(ClientKitError);
+  });
+
+  it("merges default runtime metadata and ctx for workflow runs", async () => {
+    const now = new Date().toISOString();
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        runId: "run-xyz",
+        status: "success",
+        steps: {},
+        metadata: { tenant: "aidalinfo", userId: "42" },
+        ctx: { traceId: "trace-123", locale: "fr-FR" },
+        startedAt: now,
+        finishedAt: now,
+      }),
+    );
+
+    const client = new ClientKit({
+      baseUrl,
+      fetch: fetchMock,
+      runtime: {
+        metadata: { tenant: "aidalinfo" },
+        ctx: { traceId: "trace-123" },
+      },
+    });
+
+    await client.runWorkflow("enrich-data", {
+      inputData: { id: "1" },
+      metadata: { userId: "42" },
+      ctx: { locale: "fr-FR" },
+    });
+
+    const call = fetchMock.mock.calls.at(-1);
+    expect(call).toBeDefined();
+    const [, init] = call!;
+    expect(init?.method).toBe("POST");
+    const body = JSON.parse(init?.body as string);
+    expect(body.metadata).toEqual({ tenant: "aidalinfo", userId: "42" });
+    expect(body.ctx).toEqual({ traceId: "trace-123", locale: "fr-FR" });
+  });
+
+  it("resumes workflow runs", async () => {
+    const now = new Date().toISOString();
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        runId: "run-123",
+        status: "success",
+        steps: {},
+        metadata: {},
+        ctx: {},
+        startedAt: now,
+        finishedAt: now,
+      }),
+    );
+
+    const client = new ClientKit({ baseUrl, fetch: fetchMock });
+
+    await client.resumeWorkflow("demo", "run-123", {
+      stepId: "human-step",
+      data: { answer: "ok" },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/api/workflows/demo/runs/run-123/resume",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("raises errors when the server responds with an error", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("Internal Server Error", {
+        status: 500,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+
+    const client = new ClientKit({ baseUrl, fetch: fetchMock });
+
+    await expect(
+      client.listWorkflows(),
+    ).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("lists workflows", async () => {
+    const workflows: WorkflowSummary[] = [
+      { id: "pipeline", workflowId: "pipeline", description: "Demo" },
+    ];
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({ workflows }),
+    );
+
+    const client = new ClientKit({ baseUrl, fetch: fetchMock });
+    const result = await client.listWorkflows();
+
+    expect(result).toEqual(workflows);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.method).toBe("GET");
+    const headers = init?.headers as Headers;
+    expect(headers.get("accept")).toBe("application/json");
+  });
+
+  it("preserves base paths when building URLs", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({ agents: [] }),
+    );
+
+    const client = new ClientKit({
+      baseUrl: "https://example.com/workspace",
+      fetch: fetchMock,
+    });
+
+    await client.listAgents();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/workspace/api/agents",
+      expect.any(Object),
+    );
+  });
+});

--- a/packages/client-kit/src/index.ts
+++ b/packages/client-kit/src/index.ts
@@ -1,0 +1,2 @@
+export { ClientKit, ClientKit as default } from "./ClientKit.js";
+export * from "./ClientKit.js";

--- a/packages/client-kit/tsconfig.build.json
+++ b/packages/client-kit/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "stripInternal": true
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "dist",
+    "**/*.test.ts"
+  ]
+}

--- a/packages/client-kit/tsconfig.json
+++ b/packages/client-kit/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "es2022",
+    "resolveJsonModule": true,
+    "types": [
+      "node",
+      "vitest/globals"
+    ],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/server/src/ServerKit.ts
+++ b/packages/server/src/ServerKit.ts
@@ -486,7 +486,11 @@ export class ServerKit {
   }
 
   private async parseWorkflowBody(c: Context): Promise<{
-    options: WorkflowRunOptions<unknown, Record<string, unknown>>;
+    options: WorkflowRunOptions<
+      unknown,
+      Record<string, unknown>,
+      Record<string, unknown>
+    >;
   }> {
     const body = await this.parseJsonBody(c);
 
@@ -501,7 +505,21 @@ export class ServerKit {
       metadata: (body.metadata ?? undefined) as
         | Record<string, unknown>
         | undefined,
-    } satisfies WorkflowRunOptions<unknown, Record<string, unknown>>;
+      ctx: (body.ctx ?? undefined) as
+        | Record<string, unknown>
+        | undefined,
+      telemetry: body.telemetry as
+        | WorkflowRunOptions<
+            unknown,
+            Record<string, unknown>,
+            Record<string, unknown>
+          >["telemetry"]
+        | undefined,
+    } satisfies WorkflowRunOptions<
+      unknown,
+      Record<string, unknown>,
+      Record<string, unknown>
+    >;
 
     return { options };
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,22 @@ importers:
 
   .: {}
 
+  packages/client-kit:
+    dependencies:
+      '@ai_kit/core':
+        specifier: workspace:^
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^24.7.0
+        version: 24.7.0
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.3
+        version: 2.1.9(@types/node@24.7.0)
+
   packages/core:
     dependencies:
       '@ai-sdk/openai':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
   - packages/docs
   - packages/server
   - packages/create-ai-kit
+  - packages/client-kit


### PR DESCRIPTION
## Summary
- add the new @ai_kit/client-kit package with a typed ClientKit HTTP wrapper and accompanying tests
- update ServerKit to forward ctx and telemetry data when running workflows
- document the client usage and wire a publish workflow for npm releases

## Testing
- pnpm --filter @ai_kit/client-kit test
- pnpm --filter @ai_kit/server test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124b1344e48325b1f1c3125a8001c7)