### PR TITLE
feat: model-agnostic audio transcription + Mintlify docs + CI self-hosted runner

### DIFF
--- a/.github/workflows/manual-server-tests.yml
+++ b/.github/workflows/manual-server-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr-dev-tests.yml
+++ b/.github/workflows/pr-dev-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-create-ai-kit.yml
+++ b/.github/workflows/publish-create-ai-kit.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/realease-core.yml
+++ b/.github/workflows/realease-core.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   publish:
-    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     
     steps:
     - name: Checkout repository

--- a/.github/workflows/realease-core.yml
+++ b/.github/workflows/realease-core.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
     
     steps:
     - name: Checkout repository

--- a/.github/workflows/release-client-kit.yml
+++ b/.github/workflows/release-client-kit.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-mcp-docs.yml
+++ b/.github/workflows/release-mcp-docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-rag.yml
+++ b/.github/workflows/release-rag.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout repository

--- a/docs/superpowers/specs/2026-05-27-transcription-design.md
+++ b/docs/superpowers/specs/2026-05-27-transcription-design.md
@@ -1,0 +1,243 @@
+# Transcription Support — @ai_kit/core
+
+**Date:** 2026-05-27  
+**Status:** Approved  
+**Branch:** dev
+
+---
+
+## Context
+
+AI Kit expose des agents et workflows IA. Il n'existe aucun support audio/transcription. L'objectif est d'ajouter une brique de transcription audio model-agnostic, compatible avec tout endpoint OpenAI-compatible (Scaleway Whisper large v3, OpenAI whisper-1, etc.), et intégrable dans les agents existants via un `tool()`.
+
+---
+
+## Ce qui est ajouté
+
+Trois primitives publiques dans `@ai_kit/core` :
+
+| Export | Rôle |
+|---|---|
+| `createTranscriptionModel(config)` | Crée un modèle de transcription `TranscriptionModelV3` compatible AI SDK v6 |
+| `transcribe(options)` | Wrapper standalone : charge l'audio (path / URL / buffer), appelle le modèle, retourne le transcript |
+| `createTranscriptionTool(model, options?)` | Retourne un `tool()` AI SDK branchable directement sur un `Agent` |
+
+---
+
+## Architecture
+
+```
+packages/core/src/transcription/
+├── model.ts        # createTranscriptionModel()
+├── transcribe.ts   # transcribe()
+├── tool.ts         # createTranscriptionTool()
+└── index.ts        # re-exports des 3 primitives
+```
+
+`packages/core/src/index.ts` exporte les 3 symboles.
+
+Aucun nouveau package — tout reste dans `@ai_kit/core`.
+
+---
+
+## 1. `createTranscriptionModel(config)`
+
+### Signature
+
+```typescript
+interface TranscriptionModelConfig {
+  modelId: string;           // ex: 'whisper-large-v3'
+  apiKey: string;
+  baseURL: string;           // ex: 'https://api.scaleway.ai/v1'
+  providerName?: string;     // pour les logs, défaut: 'openai-compatible'
+}
+
+function createTranscriptionModel(config: TranscriptionModelConfig): TranscriptionModelV3
+```
+
+### Implémentation
+
+Implémente l'interface `TranscriptionModelV3` de `@ai-sdk/provider` (version courante en ai-kit : `@ai-sdk/provider@3.0.8`) :
+
+```typescript
+{
+  specificationVersion: 'v3',
+  provider: config.providerName ?? 'openai-compatible',
+  modelId: config.modelId,
+  doGenerate(options: TranscriptionModelV3CallOptions): Promise<...>
+}
+```
+
+`doGenerate` :
+1. Convertit `options.audio` (`Uint8Array | string base64`) en `Blob`
+2. Construit un `FormData` avec : `file` (Blob), `model` (modelId), `response_format=verbose_json`
+3. `POST ${baseURL}/audio/transcriptions` avec `Authorization: Bearer ${apiKey}` et les headers éventuels
+4. Mappe la réponse Scaleway/OpenAI → format `TranscriptionModelV3` :
+   - `segment.start` / `segment.end` → `startSecond` / `endSecond`
+   - Gère les erreurs HTTP avec un message clair
+
+### Mapping réponse
+
+La réponse de l'API OpenAI-compatible (`response_format=verbose_json`) :
+```json
+{
+  "text": "...",
+  "language": "fr",
+  "segments": [{ "text": "...", "start": 0.0, "end": 2.0 }]
+}
+```
+est mappée vers :
+```typescript
+{
+  text: string,
+  language: string | undefined,
+  durationInSeconds: number | undefined,  // si présent dans la réponse
+  segments: Array<{ text: string, startSecond: number, endSecond: number }>,
+  warnings: [],
+  response: { timestamp: Date, modelId: string, headers: {} }
+}
+```
+
+---
+
+## 2. `transcribe(options)`
+
+### Signature
+
+```typescript
+type AudioInput = Buffer | Uint8Array | string;
+type AudioInputType = 'buffer' | 'path' | 'url';
+
+interface TranscribeOptions {
+  model: TranscriptionModelV3;
+  audio: AudioInput;
+  inputType?: AudioInputType;   // auto-détecté si absent
+  mediaType?: string;           // ex: 'audio/wav' — optionnel, le provider détecte
+  language?: string;            // ISO-639-1, passé en providerOptions
+  providerOptions?: Record<string, Record<string, unknown>>;
+  abortSignal?: AbortSignal;
+}
+
+interface TranscribeResult {
+  text: string;
+  segments: Array<{ text: string; startSecond: number; endSecond: number }>;
+  language: string | undefined;
+  durationInSeconds: number | undefined;
+}
+
+function transcribe(options: TranscribeOptions): Promise<TranscribeResult>
+```
+
+### Logique d'auto-détection du `inputType`
+
+Quand `inputType` est absent :
+- `Buffer` ou `Uint8Array` → `'buffer'`
+- `string` commençant par `http://` ou `https://` → `'url'`
+- Tout autre `string` → `'path'`
+
+### Chargement selon `inputType`
+
+| inputType | Action |
+|---|---|
+| `'buffer'` | Passé directement à `experimental_transcribe` |
+| `'path'` | `readFile(audio)` → `Uint8Array` |
+| `'url'` | `fetch(audio)` → `arrayBuffer()` → `Uint8Array` |
+
+Le `mediaType` est passé à `experimental_transcribe` en `mediaType`. Si absent, l'API le détecte depuis le contenu du fichier.
+
+Le `language` est passé dans `providerOptions` sous la clé du `provider` du modèle.
+
+---
+
+## 3. `createTranscriptionTool(model, options?)`
+
+### Signature
+
+```typescript
+interface TranscriptionToolOptions {
+  description?: string;   // description du tool pour le LLM
+  toolName?: string;      // nom du tool, défaut: 'transcribeAudio'
+}
+
+function createTranscriptionTool(
+  model: TranscriptionModelV3,
+  options?: TranscriptionToolOptions
+): Tool
+```
+
+### Schema du tool (Zod)
+
+```typescript
+z.object({
+  audio: z.string().describe('Chemin de fichier, URL http(s), ou contenu base64 de l\'audio'),
+  inputType: z.enum(['path', 'url', 'base64']).describe('Type de l\'input audio'),
+  mediaType: z.string().optional().describe('Type MIME, ex: audio/wav, audio/mp3'),
+  language: z.string().optional().describe('Code langue ISO-639-1, ex: fr, en'),
+})
+```
+
+### Execute
+
+Appelle `transcribe()` avec les paramètres. Pour `inputType: 'base64'`, convertit en `Uint8Array` avant de passer à `transcribe()` avec `inputType: 'buffer'`.
+
+Retourne `{ text, language, durationInSeconds, segmentCount }` — le texte est ce que le LLM exploite ensuite.
+
+### Usage type
+
+```typescript
+const whisperModel = createTranscriptionModel({
+  modelId: 'whisper-large-v3',
+  apiKey: process.env.SCALEWAY_API_KEY!,
+  baseURL: 'https://api.scaleway.ai/v1',
+  providerName: 'scaleway',
+})
+
+const agent = new Agent({
+  name: 'medical-assistant',
+  model: scaleway('gpt-oss-120b'),
+  tools: {
+    transcribeAudio: createTranscriptionTool(whisperModel, {
+      description: 'Transcrit un enregistrement audio médical en texte',
+    }),
+  },
+  loopTools: true,
+})
+```
+
+---
+
+## Dépendances
+
+- `experimental_transcribe` depuis `ai` (déjà en dépendance : `ai@6.0.149`) ✅
+- `TranscriptionModelV3` depuis `@ai-sdk/provider` (déjà en dépendance : `@ai-sdk/provider@3.0.8`) ✅
+- `readFile` depuis `node:fs/promises` (Node built-in) ✅
+- `zod` (déjà en dépendance) ✅
+- `tool` depuis `ai` (déjà en dépendance) ✅
+
+Aucune nouvelle dépendance.
+
+---
+
+## Formats audio supportés
+
+Scaleway Whisper large v3 supporte (identique à OpenAI Whisper) :
+`flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, `webm`
+
+---
+
+## Ce qui n'est PAS dans ce scope
+
+- Streaming de la transcription (l'API Whisper est synchrone)
+- Support de `speech()` (text-to-speech) — feature séparée
+- Shortcut `scaleway.transcription()` sur le provider Scaleway — peut être ajouté plus tard
+- Gestion des fichiers > 25 Mo (limite OpenAI/Scaleway) — erreur propagée telle quelle par le provider
+
+---
+
+## Tests à écrire
+
+Un script de test manuel dans `packages/core/src/transcription/` (non committé, juste pour validation locale) qui :
+1. Génère un WAV de 2s avec `ffmpeg`
+2. Appelle `transcribe()` avec `inputType: 'path'`
+3. Appelle `transcribe()` avec `inputType: 'buffer'`
+4. Crée un agent avec `createTranscriptionTool()` et lui envoie un path audio

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -50,6 +50,89 @@ console.log(run.status, run.result);
 
 Check the documentation for advanced agent samples, Langfuse integration, and human-in-the-loop steps.
 
+---
+
+## Transcription
+
+`@ai_kit/core` includes model-agnostic audio transcription support, compatible with any OpenAI-compatible endpoint (Scaleway Whisper large v3, OpenAI whisper-1, etc.).
+
+### Three public primitives
+
+| Export | Role |
+|---|---|
+| `createTranscriptionModel(config)` | Creates a `TranscriptionModelV3` provider |
+| `transcribe(options)` | Standalone function: loads audio (path / URL / buffer), calls the model, returns the transcript |
+| `createTranscriptionTool(model, options?)` | Returns an AI SDK `tool()` to attach directly to an `Agent` |
+
+### `createTranscriptionModel`
+
+```ts
+import { createTranscriptionModel } from "@ai_kit/core";
+
+const whisperModel = createTranscriptionModel({
+  modelId: "whisper-large-v3",
+  apiKey: process.env.SCALEWAY_API_KEY!,
+  baseURL: "https://api.scaleway.ai/v1",
+  providerName: "scaleway", // optional, used in logs
+});
+```
+
+Supports any OpenAI-compatible `/audio/transcriptions` endpoint (`response_format=verbose_json`).
+
+### `transcribe`
+
+```ts
+import { transcribe } from "@ai_kit/core";
+
+// From a file path
+const result = await transcribe({
+  model: whisperModel,
+  audio: "/path/to/audio.wav",
+  inputType: "path",         // "path" | "url" | "buffer" — auto-detected if omitted
+  language: "fr",            // optional ISO-639-1 code
+});
+
+console.log(result.text);
+// result.segments → [{ text, startSecond, endSecond }]
+// result.language, result.durationInSeconds
+```
+
+`audio` accepts a file path, an `http(s)` URL, or a `Buffer` / `Uint8Array`. The `inputType` is auto-detected when omitted.
+
+### `createTranscriptionTool` — attach to an Agent
+
+```ts
+import { createTranscriptionModel, createTranscriptionTool } from "@ai_kit/core";
+import { Agent } from "@ai_kit/core";
+import { scaleway } from "@ai_kit/core";
+
+const whisperModel = createTranscriptionModel({
+  modelId: "whisper-large-v3",
+  apiKey: process.env.SCALEWAY_API_KEY!,
+  baseURL: "https://api.scaleway.ai/v1",
+});
+
+const agent = new Agent({
+  name: "medical-assistant",
+  model: scaleway("gpt-oss-120b"),
+  tools: {
+    transcribeAudio: createTranscriptionTool(whisperModel, {
+      description: "Transcrit un enregistrement audio médical en texte",
+    }),
+  },
+});
+
+const result = await agent.generate({
+  prompt: "Transcris ce fichier : /recordings/consultation.mp3",
+});
+```
+
+The tool schema exposed to the LLM: `audio` (path / URL / base64), `inputType`, `language`.
+
+### Supported audio formats
+
+`flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, `webm` (identical to OpenAI Whisper).
+
 ## Where does `@ai_kit/server` fit?
 
 [`@ai_kit/server`](https://www.npmjs.com/package/@ai_kit/server) complements the core by adding:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "@ai-sdk/openai": "3.0.51",
     "@ai-sdk/openai-compatible": "2.0.40",
     "@ai-sdk/provider": "^3.0.0",
-    "@ai-sdk/provider-utils": "^3.0.10",
+    "@ai-sdk/provider-utils": "^4.0.23",
     "@opentelemetry/api": "^1.9.0",
     "@toon-format/toon": "^0.9.0",
     "@types/node": "^24.5.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai_kit/core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@ai-sdk/openai": "3.0.51",
     "@ai-sdk/openai-compatible": "2.0.40",
-    "@ai-sdk/provider": "^2.0.0",
+    "@ai-sdk/provider": "^3.0.0",
     "@ai-sdk/provider-utils": "^3.0.10",
     "@opentelemetry/api": "^1.9.0",
     "@toon-format/toon": "^0.9.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,3 +11,4 @@ export {
     streamWithStructuredPipeline,
 } from "./agents/structurePipeline.js";
 export * from "./telemetry/langfuse.js";
+export * from "./transcription/index.js";

--- a/packages/core/src/transcription/index.ts
+++ b/packages/core/src/transcription/index.ts
@@ -1,0 +1,13 @@
+// packages/core/src/transcription/index.ts
+export { createTranscriptionModel } from "./model.js";
+export { transcribe } from "./transcribe.js";
+export { createTranscriptionTool } from "./tool.js";
+export type {
+  TranscriptionModelConfig,
+  AudioInput,
+  AudioInputType,
+  TranscribeOptions,
+  TranscribeResult,
+  TranscriptionToolOptions,
+  TranscriptionModelV3,
+} from "./types.js";

--- a/packages/core/src/transcription/model.ts
+++ b/packages/core/src/transcription/model.ts
@@ -1,0 +1,79 @@
+// packages/core/src/transcription/model.ts
+import type {
+  TranscriptionModelV3,
+  TranscriptionModelV3CallOptions,
+} from "@ai-sdk/provider";
+import type { TranscriptionModelConfig } from "./types.js";
+
+export function createTranscriptionModel(
+  config: TranscriptionModelConfig,
+): TranscriptionModelV3 {
+  const provider = config.providerName ?? "openai-compatible";
+
+  return {
+    specificationVersion: "v3",
+    provider,
+    modelId: config.modelId,
+
+    async doGenerate(options: TranscriptionModelV3CallOptions) {
+      const audioData =
+        typeof options.audio === "string"
+          ? Uint8Array.from(atob(options.audio), (c) => c.charCodeAt(0))
+          : options.audio;
+
+      const blob = new Blob([audioData], {
+        type: options.mediaType ?? "audio/wav",
+      });
+
+      const form = new FormData();
+      form.append("file", blob, "audio.wav");
+      form.append("model", config.modelId);
+      form.append("response_format", "verbose_json");
+
+      const extraHeaders = Object.fromEntries(
+        Object.entries(options.headers ?? {}).filter(([, v]) => v !== undefined)
+      ) as Record<string, string>;
+
+      const res = await fetch(`${config.baseURL}/audio/transcriptions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+          ...extraHeaders,
+        },
+        body: form,
+        signal: options.abortSignal,
+      });
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => "(no body)");
+        throw new Error(
+          `Transcription API error ${res.status} ${res.statusText}: ${body}`,
+        );
+      }
+
+      const json = (await res.json()) as {
+        text: string;
+        language?: string;
+        duration?: number;
+        segments?: Array<{ text: string; start: number; end: number }>;
+      };
+
+      return {
+        text: json.text,
+        language: json.language,
+        durationInSeconds: json.duration,
+        segments: (json.segments ?? []).map((s) => ({
+          text: s.text,
+          startSecond: s.start,
+          endSecond: s.end,
+        })),
+        warnings: [],
+        response: {
+          timestamp: new Date(),
+          modelId: config.modelId,
+          headers: {},
+        },
+      };
+    },
+  };
+}

--- a/packages/core/src/transcription/model.ts
+++ b/packages/core/src/transcription/model.ts
@@ -21,7 +21,7 @@ export function createTranscriptionModel(
           ? Uint8Array.from(atob(options.audio), (c) => c.charCodeAt(0))
           : options.audio;
 
-      const blob = new Blob([audioData], {
+      const blob = new Blob([audioData as BlobPart], {
         type: options.mediaType ?? "audio/wav",
       });
 

--- a/packages/core/src/transcription/tool.ts
+++ b/packages/core/src/transcription/tool.ts
@@ -13,10 +13,6 @@ const transcriptionSchema = z.object({
   inputType: z
     .enum(["path", "url", "base64"])
     .describe("Type de l'input audio"),
-  mediaType: z
-    .string()
-    .optional()
-    .describe("Type MIME, ex: audio/wav, audio/mp3"),
   language: z
     .string()
     .optional()
@@ -32,7 +28,7 @@ export function createTranscriptionTool(
       options?.description ??
       "Transcrit un fichier audio en texte. Accepte un chemin de fichier, une URL ou un contenu base64.",
     inputSchema: transcriptionSchema,
-    async execute({ audio, inputType, mediaType, language }: z.infer<typeof transcriptionSchema>) {
+    async execute({ audio, inputType, language }: z.infer<typeof transcriptionSchema>) {
       let audioData: string | Uint8Array;
       let resolvedInputType: "buffer" | "path" | "url";
 
@@ -48,7 +44,6 @@ export function createTranscriptionTool(
         model,
         audio: audioData,
         inputType: resolvedInputType,
-        mediaType,
         language,
       });
 

--- a/packages/core/src/transcription/tool.ts
+++ b/packages/core/src/transcription/tool.ts
@@ -33,14 +33,15 @@ export function createTranscriptionTool(
       "Transcrit un fichier audio en texte. Accepte un chemin de fichier, une URL ou un contenu base64.",
     inputSchema: transcriptionSchema,
     async execute({ audio, inputType, mediaType, language }: z.infer<typeof transcriptionSchema>) {
-      let audioData: string | Uint8Array = audio;
-      let resolvedInputType: "buffer" | "path" | "url" = inputType as
-        | "path"
-        | "url";
+      let audioData: string | Uint8Array;
+      let resolvedInputType: "buffer" | "path" | "url";
 
       if (inputType === "base64") {
         audioData = Uint8Array.from(atob(audio), (c) => c.charCodeAt(0));
         resolvedInputType = "buffer";
+      } else {
+        audioData = audio;
+        resolvedInputType = inputType;
       }
 
       const result = await transcribe({

--- a/packages/core/src/transcription/tool.ts
+++ b/packages/core/src/transcription/tool.ts
@@ -1,0 +1,62 @@
+// packages/core/src/transcription/tool.ts
+import { tool } from "ai";
+import { z } from "zod";
+import { transcribe } from "./transcribe.js";
+import type { TranscriptionModelV3, TranscriptionToolOptions } from "./types.js";
+
+const transcriptionSchema = z.object({
+  audio: z
+    .string()
+    .describe(
+      "Chemin de fichier, URL http(s), ou contenu base64 de l'audio",
+    ),
+  inputType: z
+    .enum(["path", "url", "base64"])
+    .describe("Type de l'input audio"),
+  mediaType: z
+    .string()
+    .optional()
+    .describe("Type MIME, ex: audio/wav, audio/mp3"),
+  language: z
+    .string()
+    .optional()
+    .describe("Code langue ISO-639-1, ex: fr, en"),
+});
+
+export function createTranscriptionTool(
+  model: TranscriptionModelV3,
+  options?: TranscriptionToolOptions,
+) {
+  return tool({
+    description:
+      options?.description ??
+      "Transcrit un fichier audio en texte. Accepte un chemin de fichier, une URL ou un contenu base64.",
+    inputSchema: transcriptionSchema,
+    async execute({ audio, inputType, mediaType, language }: z.infer<typeof transcriptionSchema>) {
+      let audioData: string | Uint8Array = audio;
+      let resolvedInputType: "buffer" | "path" | "url" = inputType as
+        | "path"
+        | "url";
+
+      if (inputType === "base64") {
+        audioData = Uint8Array.from(atob(audio), (c) => c.charCodeAt(0));
+        resolvedInputType = "buffer";
+      }
+
+      const result = await transcribe({
+        model,
+        audio: audioData,
+        inputType: resolvedInputType,
+        mediaType,
+        language,
+      });
+
+      return {
+        text: result.text,
+        language: result.language,
+        durationInSeconds: result.durationInSeconds,
+        segmentCount: result.segments.length,
+      };
+    },
+  });
+}

--- a/packages/core/src/transcription/transcribe.test.ts
+++ b/packages/core/src/transcription/transcribe.test.ts
@@ -67,7 +67,9 @@ describe("transcription", () => {
         prompt: "Transcris le fichier audio : /tmp/test-transcription.wav",
       });
 
-      expect(result.text.trim().length).toBeGreaterThan(0);
+      // The agent must have called the tool (at least one step with tool calls)
+      const toolCallSteps = result.steps.filter((s) => s.toolCalls?.length > 0);
+      expect(toolCallSteps.length).toBeGreaterThan(0);
     },
     60_000,
   );

--- a/packages/core/src/transcription/transcribe.test.ts
+++ b/packages/core/src/transcription/transcribe.test.ts
@@ -1,0 +1,74 @@
+// packages/core/src/transcription/transcribe.test.ts
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+import { createTranscriptionModel } from "./model.js";
+import { transcribe } from "./transcribe.js";
+import { createTranscriptionTool } from "./tool.js";
+import { Agent } from "../agents/index.js";
+import { scaleway } from "../shared/utils/provider/scaleway.js";
+
+const apiKey = process.env.SCALEWAY_API_KEY;
+if (!apiKey) throw new Error("SCALEWAY_API_KEY is required for these tests");
+
+const whisperModel = createTranscriptionModel({
+  modelId: "whisper-large-v3",
+  apiKey,
+  baseURL: "https://api.scaleway.ai/v1",
+  providerName: "scaleway",
+});
+
+describe("transcription", () => {
+  it(
+    "transcribes from a file path",
+    async () => {
+      const result = await transcribe({
+        model: whisperModel,
+        audio: "/tmp/test-transcription.wav",
+        inputType: "path",
+        mediaType: "audio/wav",
+      });
+      expect(typeof result.text).toBe("string");
+      expect(Array.isArray(result.segments)).toBe(true);
+    },
+    30_000,
+  );
+
+  it(
+    "transcribes from a buffer",
+    async () => {
+      const buf = await readFile("/tmp/test-transcription.wav");
+      const result = await transcribe({
+        model: whisperModel,
+        audio: new Uint8Array(buf),
+        inputType: "buffer",
+        mediaType: "audio/wav",
+      });
+      expect(typeof result.text).toBe("string");
+    },
+    30_000,
+  );
+
+  it(
+    "agent uses createTranscriptionTool to transcribe a path",
+    async () => {
+      const transcribeTool = createTranscriptionTool(whisperModel, {
+        description: "Transcrit un fichier audio en texte",
+      });
+
+      const agent = new Agent({
+        name: "transcription-test-agent",
+        model: scaleway("llama-3.3-70b-instruct"),
+        tools: { transcribeAudio: transcribeTool },
+        instructions:
+          "When asked to transcribe a file, call the transcribeAudio tool and return the resulting text.",
+      });
+
+      const result = await agent.generate({
+        prompt: "Transcris le fichier audio : /tmp/test-transcription.wav",
+      });
+
+      expect(result.text.trim().length).toBeGreaterThan(0);
+    },
+    60_000,
+  );
+});

--- a/packages/core/src/transcription/transcribe.test.ts
+++ b/packages/core/src/transcription/transcribe.test.ts
@@ -25,7 +25,6 @@ describe("transcription", () => {
         model: whisperModel,
         audio: "/tmp/test-transcription.wav",
         inputType: "path",
-        mediaType: "audio/wav",
       });
       expect(typeof result.text).toBe("string");
       expect(Array.isArray(result.segments)).toBe(true);
@@ -41,7 +40,6 @@ describe("transcription", () => {
         model: whisperModel,
         audio: new Uint8Array(buf),
         inputType: "buffer",
-        mediaType: "audio/wav",
       });
       expect(typeof result.text).toBe("string");
     },

--- a/packages/core/src/transcription/transcribe.ts
+++ b/packages/core/src/transcription/transcribe.ts
@@ -1,6 +1,6 @@
 // packages/core/src/transcription/transcribe.ts
 import { readFile } from "node:fs/promises";
-import type { JSONObject } from "@ai-sdk/provider";
+import { experimental_transcribe } from "ai";
 import type {
   AudioInput,
   AudioInputType,
@@ -53,17 +53,17 @@ export async function transcribe(
     };
   }
 
-  const result = await options.model.doGenerate({
+  const result = await experimental_transcribe({
+    model: options.model as any,
     audio: audioData,
-    mediaType: options.mediaType ?? "audio/wav",
-    providerOptions: providerOptions as Record<string, JSONObject>,
+    ...(options.mediaType !== undefined && { mediaType: options.mediaType }),
+    providerOptions: providerOptions as any,
     abortSignal: options.abortSignal,
-    headers: {},
   });
 
   return {
     text: result.text,
-    segments: result.segments ?? [],
+    segments: result.segments,
     language: result.language,
     durationInSeconds: result.durationInSeconds,
   };

--- a/packages/core/src/transcription/transcribe.ts
+++ b/packages/core/src/transcription/transcribe.ts
@@ -23,9 +23,10 @@ async function loadAudio(
   inputType: AudioInputType,
 ): Promise<Uint8Array> {
   if (inputType === "buffer") {
-    return audio instanceof Uint8Array
-      ? audio
-      : new Uint8Array(audio as unknown as ArrayBuffer);
+    if (audio instanceof Uint8Array) return audio;
+    // Buffer extends Uint8Array — copy via shared underlying ArrayBuffer
+    if (Buffer.isBuffer(audio)) return new Uint8Array(audio.buffer, audio.byteOffset, audio.byteLength);
+    throw new Error("Expected Buffer or Uint8Array for inputType 'buffer'");
   }
   if (inputType === "path") {
     const buf = await readFile(audio as string);
@@ -56,14 +57,14 @@ export async function transcribe(
   const result = await experimental_transcribe({
     model: options.model as any,
     audio: audioData,
-    ...(options.mediaType !== undefined && { mediaType: options.mediaType }),
+    // experimental_transcribe auto-detects media type from audio bytes
     providerOptions: providerOptions as any,
     abortSignal: options.abortSignal,
   });
 
   return {
     text: result.text,
-    segments: result.segments,
+    segments: result.segments ?? [],
     language: result.language,
     durationInSeconds: result.durationInSeconds,
   };

--- a/packages/core/src/transcription/transcribe.ts
+++ b/packages/core/src/transcription/transcribe.ts
@@ -1,0 +1,70 @@
+// packages/core/src/transcription/transcribe.ts
+import { readFile } from "node:fs/promises";
+import type { JSONObject } from "@ai-sdk/provider";
+import type {
+  AudioInput,
+  AudioInputType,
+  TranscribeOptions,
+  TranscribeResult,
+} from "./types.js";
+
+function detectInputType(audio: AudioInput): AudioInputType {
+  if (audio instanceof Uint8Array || Buffer.isBuffer(audio)) return "buffer";
+  if (
+    typeof audio === "string" &&
+    (audio.startsWith("http://") || audio.startsWith("https://"))
+  )
+    return "url";
+  return "path";
+}
+
+async function loadAudio(
+  audio: AudioInput,
+  inputType: AudioInputType,
+): Promise<Uint8Array> {
+  if (inputType === "buffer") {
+    return audio instanceof Uint8Array
+      ? audio
+      : new Uint8Array(audio as unknown as ArrayBuffer);
+  }
+  if (inputType === "path") {
+    const buf = await readFile(audio as string);
+    return new Uint8Array(buf);
+  }
+  // url
+  const response = await fetch(audio as string);
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+export async function transcribe(
+  options: TranscribeOptions,
+): Promise<TranscribeResult> {
+  const inputType = options.inputType ?? detectInputType(options.audio);
+  const audioData = await loadAudio(options.audio, inputType);
+
+  const providerOptions: Record<string, Record<string, unknown>> =
+    options.providerOptions ?? {};
+
+  if (options.language) {
+    const providerName = options.model.provider;
+    providerOptions[providerName] = {
+      ...(providerOptions[providerName] ?? {}),
+      language: options.language,
+    };
+  }
+
+  const result = await options.model.doGenerate({
+    audio: audioData,
+    mediaType: options.mediaType ?? "audio/wav",
+    providerOptions: providerOptions as Record<string, JSONObject>,
+    abortSignal: options.abortSignal,
+    headers: {},
+  });
+
+  return {
+    text: result.text,
+    segments: result.segments ?? [],
+    language: result.language,
+    durationInSeconds: result.durationInSeconds,
+  };
+}

--- a/packages/core/src/transcription/transcribe.ts
+++ b/packages/core/src/transcription/transcribe.ts
@@ -34,6 +34,9 @@ async function loadAudio(
   }
   // url
   const response = await fetch(audio as string);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch audio from URL: ${response.status} ${response.statusText}`);
+  }
   return new Uint8Array(await response.arrayBuffer());
 }
 
@@ -57,7 +60,6 @@ export async function transcribe(
   const result = await experimental_transcribe({
     model: options.model as any,
     audio: audioData,
-    // experimental_transcribe auto-detects media type from audio bytes
     providerOptions: providerOptions as any,
     abortSignal: options.abortSignal,
   });

--- a/packages/core/src/transcription/types.ts
+++ b/packages/core/src/transcription/types.ts
@@ -17,7 +17,6 @@ export interface TranscribeOptions {
   model: TranscriptionModelV3;
   audio: AudioInput;
   inputType?: AudioInputType;
-  mediaType?: string;
   language?: string;
   providerOptions?: Record<string, Record<string, unknown>>;
   abortSignal?: AbortSignal;
@@ -32,5 +31,4 @@ export interface TranscribeResult {
 
 export interface TranscriptionToolOptions {
   description?: string;
-  toolName?: string;
 }

--- a/packages/core/src/transcription/types.ts
+++ b/packages/core/src/transcription/types.ts
@@ -1,0 +1,36 @@
+// packages/core/src/transcription/types.ts
+import type { TranscriptionModelV3 } from "@ai-sdk/provider";
+
+export type { TranscriptionModelV3 };
+
+export interface TranscriptionModelConfig {
+  modelId: string;
+  apiKey: string;
+  baseURL: string;
+  providerName?: string;
+}
+
+export type AudioInput = Buffer | Uint8Array | string;
+export type AudioInputType = "buffer" | "path" | "url";
+
+export interface TranscribeOptions {
+  model: TranscriptionModelV3;
+  audio: AudioInput;
+  inputType?: AudioInputType;
+  mediaType?: string;
+  language?: string;
+  providerOptions?: Record<string, Record<string, unknown>>;
+  abortSignal?: AbortSignal;
+}
+
+export interface TranscribeResult {
+  text: string;
+  segments: Array<{ text: string; startSecond: number; endSecond: number }>;
+  language: string | undefined;
+  durationInSeconds: number | undefined;
+}
+
+export interface TranscriptionToolOptions {
+  description?: string;
+  toolName?: string;
+}

--- a/packages/mcp-docs-server/package.json
+++ b/packages/mcp-docs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai_kit/mcp-docs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "MCP server exposing AI Kit documentation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mintlify-docs/docs.json
+++ b/packages/mintlify-docs/docs.json
@@ -70,7 +70,8 @@
                   "fr/agents/toon",
                   "fr/agents/streaming",
                   "fr/agents/runtime",
-                  "fr/agents/memory"
+                  "fr/agents/memory",
+                  "fr/agents/transcription"
                 ]
               },
               {
@@ -168,7 +169,8 @@
                   "en/agents/toon",
                   "en/agents/streaming",
                   "en/agents/runtime",
-                  "en/agents/memory"
+                  "en/agents/memory",
+                  "en/agents/transcription"
                 ]
               },
               {

--- a/packages/mintlify-docs/en/agents/transcription.mdx
+++ b/packages/mintlify-docs/en/agents/transcription.mdx
@@ -1,0 +1,94 @@
+---
+title: "Audio Transcription"
+description: "Model-agnostic audio transcription with createTranscriptionModel, transcribe, and createTranscriptionTool."
+locale: en
+---
+
+`@ai_kit/core` includes model-agnostic audio transcription support, compatible with any OpenAI-compatible endpoint (Scaleway Whisper large v3, OpenAI whisper-1, etc.).
+
+## Three public primitives
+
+| Export | Role |
+|---|---|
+| `createTranscriptionModel(config)` | Creates a `TranscriptionModelV3` provider |
+| `transcribe(options)` | Standalone function: loads audio (path / URL / buffer), calls the model, returns the transcript |
+| `createTranscriptionTool(model, options?)` | Returns an AI SDK `tool()` to attach directly to an `Agent` |
+
+## `createTranscriptionModel`
+
+```ts
+import { createTranscriptionModel } from "@ai_kit/core";
+
+const whisperModel = createTranscriptionModel({
+  modelId: "whisper-large-v3",
+  apiKey: process.env.SCALEWAY_API_KEY!,
+  baseURL: "https://api.scaleway.ai/v1",
+  providerName: "scaleway", // optional, used in logs
+});
+```
+
+Supports any OpenAI-compatible `/audio/transcriptions` endpoint (`response_format=verbose_json`).
+
+## `transcribe`
+
+```ts
+import { transcribe } from "@ai_kit/core";
+
+// From a file path
+const result = await transcribe({
+  model: whisperModel,
+  audio: "/path/to/audio.wav",
+  inputType: "path",         // "path" | "url" | "buffer" — auto-detected if omitted
+  language: "fr",            // optional ISO-639-1 code
+});
+
+console.log(result.text);
+// result.segments → [{ text, startSecond, endSecond }]
+// result.language, result.durationInSeconds
+```
+
+`audio` accepts a file path, an `http(s)` URL, or a `Buffer` / `Uint8Array`. The `inputType` is auto-detected when omitted.
+
+### Return value
+
+```ts
+interface TranscribeResult {
+  text: string;
+  segments: Array<{ text: string; startSecond: number; endSecond: number }>;
+  language: string | undefined;
+  durationInSeconds: number | undefined;
+}
+```
+
+## `createTranscriptionTool` — attach to an Agent
+
+```ts
+import { createTranscriptionModel, createTranscriptionTool, Agent } from "@ai_kit/core";
+import { scaleway } from "@ai_kit/core";
+
+const whisperModel = createTranscriptionModel({
+  modelId: "whisper-large-v3",
+  apiKey: process.env.SCALEWAY_API_KEY!,
+  baseURL: "https://api.scaleway.ai/v1",
+});
+
+const agent = new Agent({
+  name: "medical-assistant",
+  model: scaleway("gpt-oss-120b"),
+  tools: {
+    transcribeAudio: createTranscriptionTool(whisperModel, {
+      description: "Transcribe a medical audio recording to text",
+    }),
+  },
+});
+
+const result = await agent.generate({
+  prompt: "Transcribe this file: /recordings/consultation.mp3",
+});
+```
+
+The tool schema exposed to the LLM: `audio` (path / URL / base64), `inputType`, `language`.
+
+## Supported audio formats
+
+`flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, `webm` (identical to OpenAI Whisper).

--- a/packages/mintlify-docs/fr/agents/transcription.mdx
+++ b/packages/mintlify-docs/fr/agents/transcription.mdx
@@ -1,0 +1,94 @@
+---
+title: "Transcription audio"
+description: "Transcription audio agnostique du modèle avec createTranscriptionModel, transcribe et createTranscriptionTool."
+locale: fr
+---
+
+`@ai_kit/core` inclut un support de transcription audio agnostique du modèle, compatible avec n'importe quel endpoint OpenAI-compatible (Scaleway Whisper large v3, OpenAI whisper-1, etc.).
+
+## Trois primitives publiques
+
+| Export | Rôle |
+|---|---|
+| `createTranscriptionModel(config)` | Crée un provider `TranscriptionModelV3` |
+| `transcribe(options)` | Fonction standalone : charge l'audio (chemin / URL / buffer), appelle le modèle, retourne la transcription |
+| `createTranscriptionTool(model, options?)` | Retourne un `tool()` AI SDK à attacher directement à un `Agent` |
+
+## `createTranscriptionModel`
+
+```ts
+import { createTranscriptionModel } from "@ai_kit/core";
+
+const whisperModel = createTranscriptionModel({
+  modelId: "whisper-large-v3",
+  apiKey: process.env.SCALEWAY_API_KEY!,
+  baseURL: "https://api.scaleway.ai/v1",
+  providerName: "scaleway", // optionnel, utilisé dans les logs
+});
+```
+
+Compatible avec tout endpoint `/audio/transcriptions` OpenAI-compatible (`response_format=verbose_json`).
+
+## `transcribe`
+
+```ts
+import { transcribe } from "@ai_kit/core";
+
+// Depuis un chemin de fichier
+const result = await transcribe({
+  model: whisperModel,
+  audio: "/chemin/vers/audio.wav",
+  inputType: "path",         // "path" | "url" | "buffer" — auto-détecté si omis
+  language: "fr",            // code langue ISO-639-1, optionnel
+});
+
+console.log(result.text);
+// result.segments → [{ text, startSecond, endSecond }]
+// result.language, result.durationInSeconds
+```
+
+`audio` accepte un chemin de fichier, une URL `http(s)`, ou un `Buffer` / `Uint8Array`. L'`inputType` est auto-détecté si omis.
+
+### Valeur retournée
+
+```ts
+interface TranscribeResult {
+  text: string;
+  segments: Array<{ text: string; startSecond: number; endSecond: number }>;
+  language: string | undefined;
+  durationInSeconds: number | undefined;
+}
+```
+
+## `createTranscriptionTool` — attacher à un Agent
+
+```ts
+import { createTranscriptionModel, createTranscriptionTool, Agent } from "@ai_kit/core";
+import { scaleway } from "@ai_kit/core";
+
+const whisperModel = createTranscriptionModel({
+  modelId: "whisper-large-v3",
+  apiKey: process.env.SCALEWAY_API_KEY!,
+  baseURL: "https://api.scaleway.ai/v1",
+});
+
+const agent = new Agent({
+  name: "assistant-medical",
+  model: scaleway("gpt-oss-120b"),
+  tools: {
+    transcribeAudio: createTranscriptionTool(whisperModel, {
+      description: "Transcrit un enregistrement audio médical en texte",
+    }),
+  },
+});
+
+const result = await agent.generate({
+  prompt: "Transcris ce fichier : /enregistrements/consultation.mp3",
+});
+```
+
+Le schéma du tool exposé au LLM : `audio` (chemin / URL / base64), `inputType`, `language`.
+
+## Formats audio supportés
+
+`flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, `webm` (identique à OpenAI Whisper).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 2.0.40
         version: 2.0.40(zod@4.1.12)
       '@ai-sdk/provider':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^3.0.0
+        version: 3.0.8
       '@ai-sdk/provider-utils':
         specifier: ^3.0.10
         version: 3.0.10(zod@4.1.12)
@@ -2669,6 +2669,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.8
       '@ai-sdk/provider-utils':
-        specifier: ^3.0.10
-        version: 3.0.10(zod@4.1.12)
+        specifier: ^4.0.23
+        version: 4.0.23(zod@4.1.12)
       '@langfuse/otel':
         specifier: ^4.2.0
         version: 4.2.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.207.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))
@@ -222,21 +222,11 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@3.0.10':
-    resolution: {integrity: sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   '@ai-sdk/provider-utils@4.0.23':
     resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@2.0.0':
-    resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
-    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
@@ -900,9 +890,6 @@ packages:
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
-
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2839,23 +2826,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@4.1.12)
       zod: 4.1.12
 
-  '@ai-sdk/provider-utils@3.0.10(zod@4.1.12)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.0.0
-      eventsource-parser: 3.0.6
-      zod: 4.1.12
-
   '@ai-sdk/provider-utils@4.0.23(zod@4.1.12)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.1.12
-
-  '@ai-sdk/provider@2.0.0':
-    dependencies:
-      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
     dependencies:
@@ -3364,8 +3340,6 @@ snapshots:
   '@sevinf/maybe@0.5.0': {}
 
   '@sinclair/typebox@0.27.8': {}
-
-  '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 


### PR DESCRIPTION
## Summary

- **`@ai_kit/core` v1.2.0**: adds model-agnostic audio transcription with three primitives (`createTranscriptionModel`, `transcribe`, `createTranscriptionTool`) compatible with any OpenAI-compatible endpoint (Scaleway Whisper large v3, OpenAI whisper-1, etc.)
- **Mintlify docs**: new transcription pages in English and French, registered in navigation
- **`@ai_kit/mcp-docs` v1.0.4**: version bump to pick up new doc pages
- **CI**: all GitHub Actions workflows updated to use the `USE_SELF_HOSTED` org variable for runner selection

## Test plan

- [ ] Integration tests pass against Scaleway Whisper API (`SCALEWAY_API_KEY` required)
- [ ] `createTranscriptionModel` creates a valid `TranscriptionModelV3` provider
- [ ] `transcribe` works with path, URL, and buffer inputs
- [ ] `createTranscriptionTool` can be attached to an `Agent` and the LLM calls it
- [ ] Mintlify docs render correctly at `/en/agents/transcription` and `/fr/agents/transcription`
- [ ] MCP docs server serves the new transcription pages via `ai_kit-docs` tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)