### PR TITLE
feat(core): télémétrie workflow pour le moteur world

### DIFF
--- a/docs/superpowers/plans/2026-06-03-world-workflow-telemetry.md
+++ b/docs/superpowers/plans/2026-06-03-world-workflow-telemetry.md
@@ -1,0 +1,822 @@
+# World Workflow Telemetry — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter une trace racine nommée (traceName, metadata, userId, tags, input/output) aux runs durables du moteur `world` dans `WorkflowKit`, en créant le span côté dispatch et en tirant parti de la propagation traceparent automatique du SDK Vercel Workflow.
+
+**Architecture:** Un span racine OTel est ouvert dans `WorkflowKit.run/runAndWait` (branche world uniquement) avant d'appeler `adapter.run`, ce qui force le SDK à sérialiser notre traceparent dans le run durable. Les spans `STEP` et `ai.generateText` du worker s'accrochent automatiquement sous cette racine via la propagation W3C existante du SDK. Le code vit entièrement dans `packages/core/src/workflows/kit/` ; `workflow-world`, le chemin legacy, et OpenAI ne sont pas modifiés.
+
+**Tech Stack:** TypeScript, `@opentelemetry/api`, `@opentelemetry/sdk-trace-base` (tests), vitest — tout déjà présent dans `@ai_kit/core`.
+
+---
+
+## Cartographie des fichiers
+
+| Fichier | Action | Rôle |
+|---------|--------|------|
+| `packages/core/src/workflows/types.ts` | Modifier | Ajouter `tags?: string[]` à `WorkflowTelemetryOverrides` et `WorkflowTelemetryResolvedConfig` |
+| `packages/core/src/workflows/telemetry.ts` | Modifier | Propager `tags` dans `resolveWorkflowTelemetryConfig` |
+| `packages/core/src/workflows/kit/types.ts` | Modifier | Ajouter `telemetry?: WorkflowTelemetryOption` à `WorkflowRunDispatchOptions` |
+| `packages/core/src/workflows/kit/worldTelemetry.ts` | Créer | Helper `startWorldRootSpan` (span racine + attributs Langfuse) |
+| `packages/core/src/workflows/kit/WorkflowKit.ts` | Modifier | Brancher `startWorldRootSpan` dans `run` et `runAndWait` world |
+| `packages/core/src/workflows/kit/WorkflowKit.test.ts` | Modifier | Ajouter les 6 tests télémétrie world (TDD) |
+
+---
+
+## Tâche 1 — Ajouter `tags` au type `WorkflowTelemetryOverrides`
+
+**Fichiers :**
+- Modifier : `packages/core/src/workflows/types.ts`
+
+- [ ] **Écrire le test qui échoue**
+
+Dans `packages/core/src/workflows/kit/WorkflowKit.test.ts`, ajouter à la fin du fichier :
+
+```typescript
+describe("WorkflowKit — télémétrie world (tags compile-check)", () => {
+  it("WorkflowRunDispatchOptions accepte telemetry avec tags (type-check uniquement)", () => {
+    // Ce test ne fait que vérifier que le type compile — il n'a pas de logique runtime.
+    // Si les types ne sont pas définis, tsc et vitest échouent à l'import.
+    const _options: import("./types.js").WorkflowRunDispatchOptions = {
+      engine: "world",
+      telemetry: { traceName: "t", tags: ["a", "b"], userId: "u" },
+    };
+    expect(true).toBe(true);
+  });
+});
+```
+
+- [ ] **Vérifier l'échec**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | tail -20
+```
+
+Résultat attendu : erreur TypeScript (type `tags` inexistant sur `WorkflowTelemetryOverrides`).
+
+- [ ] **Implémenter le minimal**
+
+Dans `packages/core/src/workflows/types.ts`, modifier `WorkflowTelemetryOverrides` :
+
+```typescript
+export interface WorkflowTelemetryOverrides {
+  traceName?: string;
+  metadata?: Record<string, unknown>;
+  recordInputs?: boolean;
+  recordOutputs?: boolean;
+  userId?: string;
+  tags?: string[];          // ← ajouter
+}
+```
+
+- [ ] **Vérifier le passage**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | tail -10
+```
+
+Résultat attendu : PASS (1 nouveau test + tous les anciens).
+
+- [ ] **Commit**
+
+```bash
+git add packages/core/src/workflows/types.ts packages/core/src/workflows/kit/WorkflowKit.test.ts
+git commit -m "feat(core/telemetry): ajouter tags à WorkflowTelemetryOverrides"
+```
+
+---
+
+## Tâche 2 — Propager `tags` dans `resolveWorkflowTelemetryConfig`
+
+**Fichiers :**
+- Modifier : `packages/core/src/workflows/telemetry.ts`
+
+- [ ] **Vérifier le test existant (pas de nouvelle logique à tester ici)**
+
+`WorkflowTelemetryResolvedConfig` n'expose pas encore `tags`. Ajouter un test dans `WorkflowKit.test.ts` dans le describe déjà créé :
+
+```typescript
+  it("resolveWorkflowTelemetryConfig propage tags dans la config résolue", () => {
+    const { resolveWorkflowTelemetryConfig } = require("../telemetry.js");
+    const config = resolveWorkflowTelemetryConfig({
+      workflowId: "wf",
+      overrideOption: { tags: ["env:prod", "wf:form-builder"] },
+    });
+    expect(config?.tags).toEqual(["env:prod", "wf:form-builder"]);
+  });
+```
+
+> Note : ce test utilise `require` dynamique pour éviter la circularité de mock. Si vitest refuse, remplacer par un import statique en tête de fichier (pas de mock requis ici).
+
+- [ ] **Vérifier l'échec**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | grep -E "FAIL|tags"
+```
+
+Résultat attendu : le test `tags` échoue (`config.tags` est `undefined`).
+
+- [ ] **Implémenter le minimal**
+
+Dans `packages/core/src/workflows/telemetry.ts` :
+
+1. Ajouter `tags` à `WorkflowTelemetryResolvedConfig` :
+
+```typescript
+export interface WorkflowTelemetryResolvedConfig {
+  traceName: string;
+  metadata?: Record<string, unknown>;
+  recordInputs: boolean;
+  recordOutputs: boolean;
+  userId?: string;
+  tags?: string[];          // ← ajouter
+}
+```
+
+2. Dans la fonction `resolveWorkflowTelemetryConfig`, ajouter la résolution de `tags` (après `resolvedUserId`) :
+
+```typescript
+  const resolvedTags =
+    overrideOverrides?.tags ??
+    baseOverrides?.tags;
+
+  return {
+    traceName: resolvedTraceName,
+    metadata: hasMetadata ? metadata : undefined,
+    recordInputs: resolvedRecordInputs,
+    recordOutputs: resolvedRecordOutputs,
+    userId: resolvedUserId,
+    tags: resolvedTags,     // ← ajouter
+  };
+```
+
+- [ ] **Vérifier le passage**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | tail -10
+```
+
+Résultat attendu : PASS.
+
+- [ ] **Commit**
+
+```bash
+git add packages/core/src/workflows/telemetry.ts packages/core/src/workflows/kit/WorkflowKit.test.ts
+git commit -m "feat(core/telemetry): propager tags dans resolveWorkflowTelemetryConfig"
+```
+
+---
+
+## Tâche 3 — Ajouter `telemetry` à `WorkflowRunDispatchOptions`
+
+**Fichiers :**
+- Modifier : `packages/core/src/workflows/kit/types.ts`
+
+- [ ] **Le test compile-check de la tâche 1 couvre déjà ça** — vérifier qu'il passe encore :
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | tail -10
+```
+
+Résultat attendu : PASS (si ce n'est pas le cas, le type n'est pas encore ajouté — continuer).
+
+- [ ] **Implémenter**
+
+Dans `packages/core/src/workflows/kit/types.ts`, modifier `WorkflowRunDispatchOptions` :
+
+```typescript
+import type { WorkflowTelemetryOption } from "../types.js";
+
+// ...
+
+export interface WorkflowRunDispatchOptions {
+  engine?: WorkflowEngine;
+  telemetry?: WorkflowTelemetryOption;  // ← ajouter
+}
+```
+
+- [ ] **Vérifier le passage**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | tail -10
+```
+
+Résultat attendu : PASS.
+
+- [ ] **Commit**
+
+```bash
+git add packages/core/src/workflows/kit/types.ts
+git commit -m "feat(core/kit): ajouter telemetry à WorkflowRunDispatchOptions"
+```
+
+---
+
+## Tâche 4 — Créer le helper `startWorldRootSpan`
+
+**Fichiers :**
+- Créer : `packages/core/src/workflows/kit/worldTelemetry.ts`
+- Modifier (tests) : `packages/core/src/workflows/kit/WorkflowKit.test.ts`
+
+- [ ] **Écrire le test qui échoue**
+
+Ajouter dans `WorkflowKit.test.ts` (nouveau describe, après les describes existants) :
+
+```typescript
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { trace } from "@opentelemetry/api";
+
+describe("startWorldRootSpan", () => {
+  let provider: BasicTracerProvider;
+  let exporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+  });
+
+  it("crée un span nommé traceName avec les attributs Langfuse", async () => {
+    const { startWorldRootSpan } = await import("./worldTelemetry.js");
+
+    const { span } = startWorldRootSpan(
+      {
+        traceName: "form-builder",
+        metadata: { documentType: "bilan" },
+        userId: "user-42",
+        tags: ["env:prod"],
+        recordInputs: true,
+        recordOutputs: true,
+      },
+      [{ id: 1 }],
+    );
+    span.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    const s = spans[0]!;
+    expect(s.name).toBe("form-builder");
+    expect(s.attributes["name"]).toBe("form-builder");
+    expect(s.attributes["langfuse.user.id"]).toBe("user-42");
+    expect(s.attributes["user.id"]).toBe("user-42");
+    expect(s.attributes["langfuse.trace.tags"]).toBe('["env:prod"]');
+    expect(s.attributes["metadata"]).toContain("bilan");
+    expect(s.attributes["input"]).toBeDefined();
+  });
+
+  it("ne pose pas input si recordInputs=false", async () => {
+    const { startWorldRootSpan } = await import("./worldTelemetry.js");
+
+    const { span } = startWorldRootSpan(
+      { traceName: "t", recordInputs: false, recordOutputs: true },
+      ["secret"],
+    );
+    span.end();
+
+    const s = exporter.getFinishedSpans()[0]!;
+    expect(s.attributes["input"]).toBeUndefined();
+  });
+});
+```
+
+Ajouter `beforeEach` et `afterEach` aux imports de vitest en tête de fichier si pas déjà présents.
+
+- [ ] **Vérifier l'échec**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | grep -E "FAIL|worldTelemetry"
+```
+
+Résultat attendu : erreur d'import (fichier `worldTelemetry.ts` inexistant).
+
+- [ ] **Implémenter**
+
+Créer `packages/core/src/workflows/kit/worldTelemetry.ts` :
+
+```typescript
+import {
+  context as otelContext,
+  trace,
+  type Span,
+  type Context,
+} from "@opentelemetry/api";
+
+import type { WorkflowTelemetryResolvedConfig } from "../telemetry.js";
+
+const TRACER_NAME = "@ai-kit/workflow";
+
+function toJsonAttribute(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Ouvre le span racine nommé pour un run world.
+ * Le span doit être terminé par l'appelant (via span.end()).
+ * Envelopper adapter.run() dans otelContext.with(rootContext, fn) pour
+ * que le SDK Vercel sérialise ce traceparent dans le run durable.
+ */
+export function startWorldRootSpan(
+  config: WorkflowTelemetryResolvedConfig,
+  input: unknown,
+): { span: Span; rootContext: Context } {
+  const tracer = trace.getTracer(TRACER_NAME);
+
+  const span = tracer.startSpan(config.traceName, {
+    attributes: {
+      name: config.traceName,
+      "ai_kit.workflow.id": config.traceName,
+    },
+  });
+
+  if (config.metadata) {
+    span.setAttribute("metadata", toJsonAttribute(config.metadata));
+    for (const [key, val] of Object.entries(config.metadata)) {
+      const safe = key.replace(/\s+/g, "_").replace(/[^\w./-]/g, "_");
+      const primitive =
+        typeof val === "string" || typeof val === "number" || typeof val === "boolean"
+          ? val
+          : toJsonAttribute(val);
+      span.setAttribute(`ai_kit.workflow.metadata.${safe}`, primitive);
+    }
+  }
+
+  if (config.userId) {
+    span.setAttribute("langfuse.user.id", config.userId);
+    span.setAttribute("user.id", config.userId);
+    span.setAttribute("ai_kit.workflow.user_id", config.userId);
+  }
+
+  if (config.tags && config.tags.length > 0) {
+    span.setAttribute("langfuse.trace.tags", toJsonAttribute(config.tags));
+  }
+
+  if (config.recordInputs) {
+    span.setAttribute("input", toJsonAttribute(input));
+  }
+
+  const rootContext = trace.setSpan(otelContext.active(), span);
+
+  return { span, rootContext };
+}
+```
+
+- [ ] **Vérifier le passage**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | tail -10
+```
+
+Résultat attendu : PASS (tous les tests).
+
+- [ ] **Commit**
+
+```bash
+git add packages/core/src/workflows/kit/worldTelemetry.ts packages/core/src/workflows/kit/WorkflowKit.test.ts
+git commit -m "feat(core/kit): helper startWorldRootSpan pour span racine world"
+```
+
+---
+
+## Tâche 5 — Brancher la télémétrie dans `WorkflowKit.run` (fire-and-forget)
+
+**Fichiers :**
+- Modifier : `packages/core/src/workflows/kit/WorkflowKit.ts`
+- Modifier (tests) : `packages/core/src/workflows/kit/WorkflowKit.test.ts`
+
+- [ ] **Écrire le test qui échoue**
+
+Ajouter dans le describe `startWorldRootSpan` (ou créer un nouveau describe `WorkflowKit — world — télémétrie`) dans `WorkflowKit.test.ts` :
+
+```typescript
+describe("WorkflowKit — world — télémétrie run (fire-and-forget)", () => {
+  let provider: BasicTracerProvider;
+  let exporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+  });
+
+  it("sans telemetry → 0 span émis, adapter appelé normalement", async () => {
+    const handle = { runId: "r1", returnValue: Promise.resolve("ok") };
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockResolvedValue(handle),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+    const fn = async () => 42;
+    const result = await kit.run(fn, ["a"]);
+
+    expect(adapter.run).toHaveBeenCalledWith(fn, ["a"]);
+    expect(result).toBe(handle);
+    expect(exporter.getFinishedSpans()).toHaveLength(0);
+  });
+
+  it("avec telemetry → 1 span racine nommé terminé avant le return", async () => {
+    const handle = { runId: "r2", returnValue: Promise.resolve("ok") };
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockResolvedValue(handle),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+
+    async function monWorkflow(input: string) { return input; }
+
+    await kit.run(monWorkflow, ["hello"], {
+      telemetry: { traceName: "mon-workflow", userId: "u1", tags: ["t"] },
+    });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    const s = spans[0]!;
+    expect(s.name).toBe("mon-workflow");
+    expect(s.attributes["langfuse.user.id"]).toBe("u1");
+    expect(s.attributes["langfuse.trace.tags"]).toBe('["t"]');
+    expect(s.attributes["input"]).toBeDefined();
+  });
+
+  it("avec telemetry: true → traceName = fn.name", async () => {
+    const handle = { runId: "r3", returnValue: Promise.resolve("ok") };
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockResolvedValue(handle),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+
+    async function buildForm() { return "done"; }
+
+    await kit.run(buildForm, [], { telemetry: true });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.name).toBe("buildForm");
+  });
+});
+```
+
+- [ ] **Vérifier l'échec**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | grep -E "FAIL|telemetry"
+```
+
+Résultat attendu : les 3 nouveaux tests échouent (le span n'est pas créé / n'existe pas).
+
+- [ ] **Implémenter dans `WorkflowKit.ts`**
+
+Ajouter les imports en tête de fichier :
+
+```typescript
+import { context as otelContext, SpanStatusCode } from "@opentelemetry/api";
+import { startWorldRootSpan } from "./worldTelemetry.js";
+import {
+  resolveWorkflowTelemetryConfig,
+} from "../telemetry.js";
+import type { WorkflowTelemetryOption } from "../types.js";
+```
+
+Remplacer la méthode `run` (branche world uniquement) dans `WorkflowKit.ts`. Trouver :
+
+```typescript
+    const adapter = await this.#ensureAdapter();
+    return adapter.run(workflow, input as unknown[]);
+```
+
+Remplacer par :
+
+```typescript
+    const adapter = await this.#ensureAdapter();
+    const telemetryOption = (dispatch as { telemetry?: WorkflowTelemetryOption } | undefined)
+      ?.telemetry;
+    const telemetryConfig = resolveWorkflowTelemetryConfig({
+      workflowId: (workflow as { name?: string }).name ?? "workflow",
+      overrideOption: telemetryOption,
+    });
+
+    if (!telemetryConfig) {
+      return adapter.run(workflow, input as unknown[]);
+    }
+
+    const { span, rootContext } = startWorldRootSpan(telemetryConfig, input);
+    const handle = await otelContext.with(rootContext, () =>
+      adapter.run(workflow, input as unknown[]),
+    );
+    span.setStatus({ code: SpanStatusCode.OK });
+    span.end();
+    return handle;
+```
+
+- [ ] **Vérifier le passage**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | tail -10
+```
+
+Résultat attendu : PASS (tous les tests, anciens + nouveaux).
+
+- [ ] **Commit**
+
+```bash
+git add packages/core/src/workflows/kit/WorkflowKit.ts packages/core/src/workflows/kit/WorkflowKit.test.ts
+git commit -m "feat(core/kit): span racine world dans WorkflowKit.run (fire-and-forget)"
+```
+
+---
+
+## Tâche 6 — Brancher la télémétrie dans `WorkflowKit.runAndWait`
+
+**Fichiers :**
+- Modifier : `packages/core/src/workflows/kit/WorkflowKit.ts`
+- Modifier (tests) : `packages/core/src/workflows/kit/WorkflowKit.test.ts`
+
+- [ ] **Écrire le test qui échoue**
+
+Ajouter dans `WorkflowKit.test.ts` :
+
+```typescript
+describe("WorkflowKit — world — télémétrie runAndWait", () => {
+  let provider: BasicTracerProvider;
+  let exporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+  });
+
+  it("succès → span terminé OK avec output", async () => {
+    const handle = {
+      runId: "r_ok",
+      returnValue: Promise.resolve({ result: 42 }),
+    };
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockResolvedValue(handle),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+    async function computeResult(n: number) { return n * 2; }
+
+    const out = await kit.runAndWait(computeResult, [21], {
+      telemetry: { traceName: "compute", recordOutputs: true },
+    });
+
+    expect(out).toEqual({ result: 42 });
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    const s = spans[0]!;
+    expect(s.name).toBe("compute");
+    expect(s.status.code).toBe(SpanStatusCode.OK);
+    expect(s.attributes["output"]).toContain("42");
+  });
+
+  it("erreur du run → span terminé ERROR, exception propagée", async () => {
+    const handle = {
+      runId: "r_fail",
+      get returnValue() {
+        return Promise.reject(new Error("run crashed"));
+      },
+    };
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockResolvedValue(handle),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+    async function failingWorkflow() { return 0; }
+
+    await expect(
+      kit.runAndWait(failingWorkflow, [], { telemetry: true }),
+    ).rejects.toThrow("run crashed");
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.status.code).toBe(SpanStatusCode.ERROR);
+  });
+
+  it("propagation de contexte — adapter.run s'exécute dans le contexte du span racine", async () => {
+    // L'adapter crée lui-même un span enfant → on vérifie que son parent = le span racine.
+    let capturedParentSpanId: string | undefined;
+
+    const handle = { runId: "r_ctx", returnValue: Promise.resolve("done") };
+    const { trace: otelTrace, context: otelCtx } = await import("@opentelemetry/api");
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockImplementation(async () => {
+        // Lire le span actif au moment où adapter.run est appelé
+        capturedParentSpanId = otelTrace.getActiveSpan()?.spanContext().spanId;
+        return handle;
+      }),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+    async function ctxWorkflow() { return "x"; }
+
+    await kit.runAndWait(ctxWorkflow, [], { telemetry: { traceName: "ctx-test" } });
+
+    // Le span est terminé — on récupère son spanId via l'exporter
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    const rootSpanId = spans[0]!.spanContext().spanId;
+    // Le span actif vu par adapter.run au moment du dispatch = le span racine
+    expect(capturedParentSpanId).toBe(rootSpanId);
+  });
+});
+```
+
+Ajouter `SpanStatusCode` aux imports `@opentelemetry/api` en tête du fichier de test.
+
+- [ ] **Vérifier l'échec**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | grep -E "FAIL|runAndWait.*télémétrie"
+```
+
+Résultat attendu : les 3 nouveaux tests échouent.
+
+- [ ] **Implémenter dans `WorkflowKit.ts`**
+
+Trouver la branche world de `runAndWait` (après le check `if (engine === "legacy")`). Remplacer :
+
+```typescript
+    const adapter = await this.#ensureAdapter();
+    const handle = await adapter.run(workflow, input as unknown[]);
+    return handle.returnValue;
+```
+
+Par :
+
+```typescript
+    const adapter = await this.#ensureAdapter();
+    const telemetryOption = (dispatch as { telemetry?: WorkflowTelemetryOption } | undefined)
+      ?.telemetry;
+    const telemetryConfig = resolveWorkflowTelemetryConfig({
+      workflowId: (workflow as { name?: string }).name ?? "workflow",
+      overrideOption: telemetryOption,
+    });
+
+    if (!telemetryConfig) {
+      const handle = await adapter.run(workflow, input as unknown[]);
+      return handle.returnValue;
+    }
+
+    const { span, rootContext } = startWorldRootSpan(telemetryConfig, input);
+    try {
+      const handle = await otelContext.with(rootContext, () =>
+        adapter.run(workflow, input as unknown[]),
+      );
+      const result = await handle.returnValue;
+      if (telemetryConfig.recordOutputs) {
+        span.setAttribute("output", JSON.stringify(result));
+      }
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+      return result;
+    } catch (error) {
+      span.recordException(error instanceof Error ? error : new Error(String(error)));
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      span.end();
+      throw error;
+    }
+```
+
+- [ ] **Vérifier le passage**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run src/workflows/kit/WorkflowKit.test.ts 2>&1 | tail -10
+```
+
+Résultat attendu : PASS (tous les tests, anciens + nouveaux).
+
+- [ ] **Commit**
+
+```bash
+git add packages/core/src/workflows/kit/WorkflowKit.ts packages/core/src/workflows/kit/WorkflowKit.test.ts
+git commit -m "feat(core/kit): span racine world dans WorkflowKit.runAndWait (succès + erreur)"
+```
+
+---
+
+## Tâche 7 — Vérification finale : build + suite complète
+
+**Fichiers :**
+- Aucun changement de code.
+
+- [ ] **Build TypeScript**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm run build 2>&1 | tail -10
+```
+
+Résultat attendu : `build: OK`, 0 erreur tsc.
+
+- [ ] **Suite complète**
+
+```bash
+cd /home/killian/Documents/dev/ai-kit/packages/core
+pnpm vitest run 2>&1 | tail -10
+```
+
+Résultat attendu : tous les tests passent (149+ tests, 7 skippés env-gated), 0 régression.
+
+- [ ] **Bump de version (minor) et commit**
+
+Dans `packages/core/package.json`, changer `"version"` de `1.9.0` à `1.10.0`.
+
+```bash
+git add packages/core/package.json
+git commit -m "chore(release): @ai_kit/core 1.10.0"
+```
+
+---
+
+## Tâche 8 — Branch, PR et merge vers `dev` (pas de merge vers main avant validation manuelle)
+
+- [ ] **Créer la branche et pousser**
+
+```bash
+git checkout -b feat/world-workflow-telemetry
+# cherry-pick ou reset : tous les commits de ce plan sont déjà sur cette branche
+git push -u origin feat/world-workflow-telemetry
+```
+
+- [ ] **Ouvrir la PR vers `dev`**
+
+```bash
+gh pr create --repo aidalinfo/ai-kit --base dev --head feat/world-workflow-telemetry \
+  --title "feat(core): télémétrie workflow pour le moteur world" \
+  --body "Ajoute une trace racine nommée (traceName, metadata, userId, tags, input/output) aux runs world. Span créé côté dispatch ; propagation traceparent du SDK Vercel assure le parentage des spans STEP et ai.generateText. Opt-in strict, legacy inchangé. Voir docs/superpowers/specs/2026-06-03-world-workflow-telemetry-design.md"
+```
+
+- [ ] **⚠️ Validation manuelle avant merge `dev` → `main`**
+
+Avant de merger vers `main` (ce qui publierait 1.10.0 sur npm) :
+- Dans un env avec world DB réelle (postgres/mongo) et Langfuse configuré, appeler `kit.runAndWait(monWorkflow, args, { telemetry: { traceName: "mon-workflow", userId: "...", tags: ["..."] } })`.
+- Vérifier dans Langfuse que les spans `STEP {name}` et `ai.generateText` apparaissent **en enfants** de la trace racine nommée (arbre, pas traces liées).
+- Si les spans s'affichent en lien (pas en arbre), documenter et appliquer le fallback D (SpanProcessor hôte enrichissant les spans SDK via baggage OTel — spec disponible).
+
+- [ ] **Merge `dev` → `main` après validation manuelle** (déclenche la publication npm 1.10.0)

--- a/docs/superpowers/specs/2026-06-03-world-workflow-telemetry-design.md
+++ b/docs/superpowers/specs/2026-06-03-world-workflow-telemetry-design.md
@@ -1,0 +1,174 @@
+# Spec : télémétrie workflow pour le moteur « world »
+
+**Date :** 2026-06-03
+**Package cible :** `@ai_kit/core`
+**Statut :** approuvé — prêt pour le plan d'implémentation
+
+---
+
+## Contexte et problème
+
+Il existe deux exécuteurs de workflow dans `@ai_kit/core` :
+
+| Exécuteur | Fichier | Télémétrie |
+|-----------|---------|------------|
+| Legacy (in-process) | `workflows/workflowRun.ts` → `WorkflowRunTelemetry` | ✅ span racine nommée (traceName), metadata, tags, langfuse.user.id, input/output |
+| World (durable) | `WorkflowKit.run/runAndWait` → `adapter.run` | ❌ aucune |
+
+Sur le moteur world, Langfuse voit des spans `ai.generateText` orphelins : `name=""`, `tags=[]`, `metadata={}`, `userId=null`. La montée 1.6→1.9 n'a rien ajouté côté télémétrie world ; le trou existait déjà, il devient visible dès que les runs passent durablement par world.
+
+**Investigation SDK (`workflow@4.3.1`) :**
+- Le SDK émet ses propres spans OTel (tracer `"workflow"`) : `workflow.start {name}` au dispatch, `STEP {name}` sur le worker — portant `WorkflowName`, `WorkflowRunId`, `StepId`, etc.
+- Il propage le W3C traceparent via `serializeTraceCarrier()` (inject à l'enqueue) / `withTraceContext()` (extract sur le worker) → les spans enfants s'accrochent déjà à *quelque chose*, mais ce quelque chose n'est pas une racine nommée par l'application.
+- `start()` n'offre **aucun champ** pour passer des métadonnées applicatives (`tags`, `traceName`, `userId`).
+- `createWorld()` n'expose **aucun hook** (pas d'observers, pas de callbacks, pas d'option OTel).
+- `getWorkflowMetadata()` (accessible dans un step) ne retourne que `{workflowName, workflowRunId, startedAt, url}`.
+
+---
+
+## Objectif
+
+Un run durable (`world`) produit dans Langfuse **une seule trace racine nommée** portant `traceName`, `metadata`, `langfuse.user.id`, `langfuse.trace.tags` et l'input (+ output pour `runAndWait`), sous laquelle apparaissent les spans `STEP` du SDK et les spans `ai.generateText` imbriqués.
+
+**Opt-in strict :** aucune config → aucun span → aucun overhead.
+**Legacy et OpenAI inchangés.**
+
+---
+
+## Approche retenue : span racine côté dispatch (A)
+
+Le `serializeTraceCarrier()` du SDK lit `otelContext.active()` pendant `start()`. Il suffit d'envelopper l'appel `adapter.run(...)` dans le contexte OTel de notre span racine pour que le SDK sérialise automatiquement notre traceparent dans le run — sans toucher aucun interne du SDK.
+
+Le code vit **entièrement dans `WorkflowKit`** (`packages/core/src/workflows/kit/`). `workflow-world` n'est pas modifié.
+
+---
+
+## Design
+
+### 1. Configuration — `WorkflowRunDispatchOptions`
+
+```ts
+// packages/core/src/workflows/kit/types.ts
+interface WorkflowRunDispatchOptions {
+  engine?: WorkflowEngine;
+  telemetry?: WorkflowTelemetryOption;
+  // WorkflowTelemetryOption = boolean | {
+  //   traceName?: string     // défaut : fn.name
+  //   metadata?: Record<string, unknown>
+  //   userId?: string        // → langfuse.user.id / user.id
+  //   tags?: string[]        // → langfuse.trace.tags  ← nouveau champ partagé
+  //   recordInputs?: boolean  // défaut : true
+  //   recordOutputs?: boolean // défaut : true
+  // }
+}
+```
+
+`traceName` est résolu exactement comme dans le chemin legacy (`resolveWorkflowTelemetryConfig`) ; si omis, on tombe sur `fn.name` (nom de la fonction workflow). C'est le seul défaut spécifique au chemin world.
+
+Le champ `tags?: string[]` est ajouté à `WorkflowTelemetryOverrides` et `WorkflowTelemetryResolvedConfig` (partagés avec legacy). Legacy ne les exploite pas tant qu'ils ne sont pas renseignés — aucune régression.
+
+### 2. Helper `startWorldRootSpan`
+
+Nouveau helper dans `WorkflowKit.ts` (ou un fichier `worldTelemetry.ts` co-localisé) :
+
+```ts
+function startWorldRootSpan(
+  config: WorkflowTelemetryResolvedConfig,
+  input: unknown,
+): { span: Span; rootContext: Context }
+```
+
+- Utilise le même tracer `@ai-kit/workflow` que le chemin legacy.
+- Nom du span = `config.traceName`.
+- Attributs posés : `name`, `ai_kit.workflow.id` (= traceName), `metadata` (JSON), `langfuse.user.id` / `user.id`, `langfuse.trace.tags` (array → JSON), `input` (si `recordInputs`).
+- Retourne `{ span, rootContext }` pour que l'appelant puisse terminer le span après le run.
+
+### 3. Branche world dans `WorkflowKit.run` et `runAndWait`
+
+**`run` (fire-and-forget) :**
+```
+config = resolveWorkflowTelemetryConfig({ workflowId: fn.name, overrideOption: dispatch.telemetry })
+si config absent → adapter.run(fn, args)  // identique à aujourd'hui
+sinon :
+  { span, rootContext } = startWorldRootSpan(config, args)
+  handle = await otelContext.with(rootCtx, () => adapter.run(fn, args))
+  span.setStatus(OK)
+  span.end()          // terminé immédiatement ; output non capturé (fire-and-forget)
+  return handle
+```
+
+**`runAndWait` :**
+```
+config = resolveWorkflowTelemetryConfig(...)
+si config absent → comportement actuel
+sinon :
+  { span, rootContext } = startWorldRootSpan(config, args)
+  try :
+    handle = await otelContext.with(rootCtx, () => adapter.run(fn, args))
+    result = await handle.returnValue
+    if config.recordOutputs : span.setAttribute("output", JSON.stringify(result))
+    span.setStatus(OK)
+    span.end()
+    return result
+  catch e :
+    span.recordException(e)
+    span.setStatus(ERROR, e.message)
+    span.end()
+    throw e            // comportement actuel préservé
+```
+
+### 4. Sûreté et no-op garanti
+
+- Pas de SDK OTel configuré → `trace.getTracer()` → tracer no-op → spans sont des no-op, pas d'exception possible.
+- `telemetry` absent de `WorkflowRunDispatchOptions` → `resolveWorkflowTelemetryConfig` retourne `undefined` → branche ignorée, comportement byte-for-byte identique.
+- Pas de dépendance ajoutée : OTel API est déjà une dépendance directe de `@ai_kit/core`.
+
+### 5. Risque empirique — parent vs span-link
+
+Le SDK lie les worker spans au contexte propagé. Selon le mode (parent-child vs span-link), Langfuse affichera soit un **arbre** (idéal) soit des **traces liées** (acceptable mais moins lisible). Ce point doit être validé sur une world DB réelle avant merge vers main.
+
+Si les spans s'affichent en lien (pas en arbre), le fallback est l'approche D (SpanProcessor hôte enrichissant les spans `workflow.start`/`STEP` via le baggage OTel) — documenté mais non implémenté dans cette spec.
+
+---
+
+## Tests
+
+### Unitaires (TDD, in-process)
+Avec le seam `__setWorkflowWorldLoader` + adapter factice + `InMemorySpanExporter` :
+
+1. `run` sans telemetry → 0 span émis, adapter appelé normalement.
+2. `run` avec `telemetry: true` → 1 span racine nommé `fn.name`, attributs `name`/`input`, span terminé avant return.
+3. `run` avec `telemetry: { traceName, metadata, userId, tags }` → attributs vérifiés.
+4. `runAndWait` succès → span terminé avec `output` et statut OK.
+5. `runAndWait` exception → span terminé avec `recordException` et statut ERROR, exception rethrow.
+6. Propagation de contexte : l'adapter factice crée un span enfant dans son `run()` et on assert que son parent est le span racine.
+
+### Validation manuelle (spike avant merge main)
+Pointer un world postgres/mongo réel (env dev/staging), vérifier dans Langfuse que les spans `STEP` et `ai.generateText` apparaissent en **enfants** de la trace racine nommée (et non en traces distinctes liées).
+
+---
+
+## Ce qui ne change pas
+
+- Chemin legacy (`workflowRun.ts`) : aucune modification.
+- `workflow-world` (`adapter.ts`, `worlds.ts`) : aucune modification.
+- Appels existants sans `telemetry` dans `WorkflowRunDispatchOptions` : comportement identique.
+- OpenAI et autres providers : non concernés.
+
+---
+
+## Utilisation côté application
+
+```ts
+// lrd-nuxt/server — appel depuis un handler
+const result = await kit.runAndWait(formBuilderWorkflow, [input], {
+  telemetry: {
+    traceName: "form-builder",
+    metadata: { documentType: input.type },
+    userId: session.userId,
+    tags: ["form-builder", "prod"],
+  },
+});
+```
+
+Sans `telemetry`, l'appel est strictement identique à aujourd'hui.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai_kit/core",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@langchain/core": "^1.1.48",
     "@opentelemetry/sdk-trace-base": "^2.2.0",
+    "@opentelemetry/sdk-trace-node": "^2.2.0",
     "@qdrant/js-client-rest": "^1.18.0",
     "@types/pg": "^8.15.6",
     "@types/ws": "^8.18.1",

--- a/packages/core/src/workflows/kit/WorkflowKit.test.ts
+++ b/packages/core/src/workflows/kit/WorkflowKit.test.ts
@@ -232,6 +232,89 @@ describe("startWorldRootSpan", () => {
   });
 });
 
+describe("WorkflowKit — world — télémétrie run (fire-and-forget)", () => {
+  let provider: BasicTracerProvider;
+  let exporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+  });
+
+  it("sans telemetry → 0 span émis, adapter appelé normalement", async () => {
+    const handle = { runId: "r1", returnValue: Promise.resolve("ok") };
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockResolvedValue(handle),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+    const fn = async () => 42;
+    const result = await kit.run(fn, ["a"]);
+
+    expect(adapter.run).toHaveBeenCalledWith(fn, ["a"]);
+    expect(result).toBe(handle);
+    expect(exporter.getFinishedSpans()).toHaveLength(0);
+  });
+
+  it("avec telemetry → 1 span racine nommé terminé avant le return", async () => {
+    const handle = { runId: "r2", returnValue: Promise.resolve("ok") };
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockResolvedValue(handle),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+
+    async function monWorkflow(input: string) { return input; }
+
+    await kit.run(monWorkflow, ["hello"], {
+      telemetry: { traceName: "mon-workflow", userId: "u1", tags: ["t"] },
+    });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    const s = spans[0]!;
+    expect(s.name).toBe("mon-workflow");
+    expect(s.attributes["langfuse.user.id"]).toBe("u1");
+    expect(s.attributes["langfuse.trace.tags"]).toBe('["t"]');
+    expect(s.attributes["input"]).toBeDefined();
+  });
+
+  it("avec telemetry: true → traceName = fn.name", async () => {
+    const handle = { runId: "r3", returnValue: Promise.resolve("ok") };
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockResolvedValue(handle),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+
+    async function buildForm() { return "done"; }
+
+    await kit.run(buildForm, [], { telemetry: true });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.name).toBe("buildForm");
+  });
+});
+
 describe("WorkflowKit — télémétrie world (tags compile-check)", () => {
   it("WorkflowRunDispatchOptions accepte telemetry avec tags (type-check uniquement)", () => {
     // Ce test ne fait que vérifier que le type compile — il n'a pas de logique runtime.

--- a/packages/core/src/workflows/kit/WorkflowKit.test.ts
+++ b/packages/core/src/workflows/kit/WorkflowKit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkflowKit, __setWorkflowWorldLoader } from "./WorkflowKit.js";
 
 afterEach(() => __setWorkflowWorldLoader());
@@ -162,6 +162,73 @@ describe("WorkflowKit — adapter injecté", () => {
       // @ts-expect-error type de world volontairement invalide
       () => new WorkflowKit({ engine: "world", world: { type: "redis", url: "x" }, adapter }),
     ).not.toThrow();
+  });
+});
+
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { trace } from "@opentelemetry/api";
+
+describe("startWorldRootSpan", () => {
+  let provider: BasicTracerProvider;
+  let exporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(provider);
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+  });
+
+  it("crée un span nommé traceName avec les attributs Langfuse", async () => {
+    const { startWorldRootSpan } = await import("./worldTelemetry.js");
+
+    const { span } = startWorldRootSpan(
+      {
+        traceName: "form-builder",
+        metadata: { documentType: "bilan" },
+        userId: "user-42",
+        tags: ["env:prod"],
+        recordInputs: true,
+        recordOutputs: true,
+      },
+      [{ id: 1 }],
+    );
+    span.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    const s = spans[0]!;
+    expect(s.name).toBe("form-builder");
+    expect(s.attributes["name"]).toBe("form-builder");
+    expect(s.attributes["langfuse.user.id"]).toBe("user-42");
+    expect(s.attributes["user.id"]).toBe("user-42");
+    expect(s.attributes["langfuse.trace.tags"]).toBe('["env:prod"]');
+    expect(s.attributes["metadata"]).toContain("bilan");
+    expect(s.attributes["input"]).toBeDefined();
+  });
+
+  it("ne pose pas input si recordInputs=false", async () => {
+    const { startWorldRootSpan } = await import("./worldTelemetry.js");
+
+    const { span } = startWorldRootSpan(
+      { traceName: "t", recordInputs: false, recordOutputs: true },
+      ["secret"],
+    );
+    span.end();
+
+    const s = exporter.getFinishedSpans()[0]!;
+    expect(s.attributes["input"]).toBeUndefined();
   });
 });
 

--- a/packages/core/src/workflows/kit/WorkflowKit.test.ts
+++ b/packages/core/src/workflows/kit/WorkflowKit.test.ts
@@ -175,4 +175,13 @@ describe("WorkflowKit — télémétrie world (tags compile-check)", () => {
     };
     expect(true).toBe(true);
   });
+
+  it("resolveWorkflowTelemetryConfig propage tags dans la config résolue", async () => {
+    const { resolveWorkflowTelemetryConfig } = await import("../telemetry.js");
+    const config = resolveWorkflowTelemetryConfig({
+      workflowId: "wf",
+      overrideOption: { tags: ["env:prod", "wf:form-builder"] },
+    });
+    expect(config?.tags).toEqual(["env:prod", "wf:form-builder"]);
+  });
 });

--- a/packages/core/src/workflows/kit/WorkflowKit.test.ts
+++ b/packages/core/src/workflows/kit/WorkflowKit.test.ts
@@ -170,7 +170,8 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { trace } from "@opentelemetry/api";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { trace, SpanStatusCode } from "@opentelemetry/api";
 
 describe("startWorldRootSpan", () => {
   let provider: BasicTracerProvider;
@@ -333,5 +334,104 @@ describe("WorkflowKit — télémétrie world (tags compile-check)", () => {
       overrideOption: { tags: ["env:prod", "wf:form-builder"] },
     });
     expect(config?.tags).toEqual(["env:prod", "wf:form-builder"]);
+  });
+});
+
+describe("WorkflowKit — world — télémétrie runAndWait", () => {
+  let provider: NodeTracerProvider;
+  let exporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+  });
+
+  it("succès → span terminé OK avec output", async () => {
+    const handle = {
+      runId: "r_ok",
+      returnValue: Promise.resolve({ result: 42 }),
+    };
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockResolvedValue(handle),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+    async function computeResult(n: number) { return n * 2; }
+
+    const out = await kit.runAndWait(computeResult, [21], {
+      telemetry: { traceName: "compute", recordOutputs: true },
+    });
+
+    expect(out).toEqual({ result: 42 });
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    const s = spans[0]!;
+    expect(s.name).toBe("compute");
+    expect(s.status.code).toBe(SpanStatusCode.OK);
+    expect(s.attributes["output"]).toContain("42");
+  });
+
+  it("erreur du run → span terminé ERROR, exception propagée", async () => {
+    const handle = {
+      runId: "r_fail",
+      get returnValue() {
+        return Promise.reject(new Error("run crashed"));
+      },
+    };
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockResolvedValue(handle),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+    async function failingWorkflow() { return 0; }
+
+    await expect(
+      kit.runAndWait(failingWorkflow, [], { telemetry: true }),
+    ).rejects.toThrow("run crashed");
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.status.code).toBe(SpanStatusCode.ERROR);
+  });
+
+  it("propagation de contexte — adapter.run s'exécute dans le contexte du span racine", async () => {
+    let capturedParentSpanId: string | undefined;
+
+    const handle = { runId: "r_ctx", returnValue: Promise.resolve("done") };
+    const adapter = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockImplementation(async () => {
+        const { trace: otelTrace } = await import("@opentelemetry/api");
+        capturedParentSpanId = otelTrace.getActiveSpan()?.spanContext().spanId;
+        return handle;
+      }),
+    };
+    __setWorkflowWorldLoader(async () => ({ createWorldAdapter: () => adapter }));
+
+    const kit = new WorkflowKit({ engine: "world", world: { type: "postgres", url: "x" } });
+    async function ctxWorkflow() { return "x"; }
+
+    await kit.runAndWait(ctxWorkflow, [], { telemetry: { traceName: "ctx-test" } });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    const rootSpanId = spans[0]!.spanContext().spanId;
+    expect(capturedParentSpanId).toBe(rootSpanId);
   });
 });

--- a/packages/core/src/workflows/kit/WorkflowKit.test.ts
+++ b/packages/core/src/workflows/kit/WorkflowKit.test.ts
@@ -164,3 +164,15 @@ describe("WorkflowKit — adapter injecté", () => {
     ).not.toThrow();
   });
 });
+
+describe("WorkflowKit — télémétrie world (tags compile-check)", () => {
+  it("WorkflowRunDispatchOptions accepte telemetry avec tags (type-check uniquement)", () => {
+    // Ce test ne fait que vérifier que le type compile — il n'a pas de logique runtime.
+    // Si les types ne sont pas définis, tsc et vitest échouent à l'import.
+    const _options: import("./types.js").WorkflowRunDispatchOptions = {
+      engine: "world",
+      telemetry: { traceName: "t", tags: ["a", "b"], userId: "u" },
+    };
+    expect(true).toBe(true);
+  });
+});

--- a/packages/core/src/workflows/kit/WorkflowKit.ts
+++ b/packages/core/src/workflows/kit/WorkflowKit.ts
@@ -1,3 +1,4 @@
+import { context as otelContext, SpanStatusCode } from "@opentelemetry/api";
 import type { Workflow } from "../workflow.js";
 import type { WorkflowRunOptions, WorkflowRunResult } from "../types.js";
 import type {
@@ -9,6 +10,8 @@ import type {
   WorldRunHandle,
   WorkflowRunDispatchOptions,
 } from "./types.js";
+import { startWorldRootSpan } from "./worldTelemetry.js";
+import { resolveWorkflowTelemetryConfig } from "../telemetry.js";
 
 const VALID_WORLD_TYPES = ["postgres", "mongodb"] as const;
 
@@ -78,7 +81,22 @@ export class WorkflowKit {
       return (workflow as Workflow<any, any, any, any>).run(input);
     }
     const adapter = await this.#ensureAdapter();
-    return adapter.run(workflow, input as unknown[]);
+    const telemetryConfig = resolveWorkflowTelemetryConfig({
+      workflowId: (workflow as { name?: string }).name ?? "workflow",
+      overrideOption: dispatch?.telemetry,
+    });
+
+    if (!telemetryConfig) {
+      return adapter.run(workflow, input as unknown[]);
+    }
+
+    const { span, rootContext } = startWorldRootSpan(telemetryConfig, input);
+    const handle = await otelContext.with(rootContext, () =>
+      adapter.run(workflow, input as unknown[]),
+    );
+    span.setStatus({ code: SpanStatusCode.OK });
+    span.end();
+    return handle;
   }
 
   // Overload: legacy engine — returns the workflow output, throws on non-success

--- a/packages/core/src/workflows/kit/WorkflowKit.ts
+++ b/packages/core/src/workflows/kit/WorkflowKit.ts
@@ -134,8 +134,37 @@ export class WorkflowKit {
       return result.result;
     }
     const adapter = await this.#ensureAdapter();
-    const handle = await adapter.run(workflow, input as unknown[]);
-    return handle.returnValue;
+    const telemetryConfig = resolveWorkflowTelemetryConfig({
+      workflowId: (workflow as { name?: string }).name ?? "workflow",
+      overrideOption: dispatch?.telemetry,
+    });
+
+    if (!telemetryConfig) {
+      const handle = await adapter.run(workflow, input as unknown[]);
+      return handle.returnValue;
+    }
+
+    const { span, rootContext } = startWorldRootSpan(telemetryConfig, input);
+    try {
+      const handle = await otelContext.with(rootContext, () =>
+        adapter.run(workflow, input as unknown[]),
+      );
+      const result = await handle.returnValue;
+      if (telemetryConfig.recordOutputs) {
+        span.setAttribute("output", JSON.stringify(result));
+      }
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+      return result;
+    } catch (error) {
+      span.recordException(error instanceof Error ? error : new Error(String(error)));
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      span.end();
+      throw error;
+    }
   }
 
   async #ensureAdapter(): Promise<WorldEngineAdapter> {

--- a/packages/core/src/workflows/kit/WorkflowKit.ts
+++ b/packages/core/src/workflows/kit/WorkflowKit.ts
@@ -91,12 +91,22 @@ export class WorkflowKit {
     }
 
     const { span, rootContext } = startWorldRootSpan(telemetryConfig, input);
-    const handle = await otelContext.with(rootContext, () =>
-      adapter.run(workflow, input as unknown[]),
-    );
-    span.setStatus({ code: SpanStatusCode.OK });
-    span.end();
-    return handle;
+    try {
+      const handle = await otelContext.with(rootContext, () =>
+        adapter.run(workflow, input as unknown[]),
+      );
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+      return handle;
+    } catch (error) {
+      span.recordException(error instanceof Error ? error : new Error(String(error)));
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      span.end();
+      throw error;
+    }
   }
 
   // Overload: legacy engine — returns the workflow output, throws on non-success
@@ -151,7 +161,13 @@ export class WorkflowKit {
       );
       const result = await handle.returnValue;
       if (telemetryConfig.recordOutputs) {
-        span.setAttribute("output", JSON.stringify(result));
+        let outputStr: string;
+        try {
+          outputStr = JSON.stringify(result);
+        } catch {
+          outputStr = String(result);
+        }
+        span.setAttribute("output", outputStr);
       }
       span.setStatus({ code: SpanStatusCode.OK });
       span.end();

--- a/packages/core/src/workflows/kit/types.ts
+++ b/packages/core/src/workflows/kit/types.ts
@@ -1,5 +1,5 @@
 import type { Workflow } from "../workflow.js";
-import type { WorkflowRunOptions, WorkflowRunResult } from "../types.js";
+import type { WorkflowRunOptions, WorkflowRunResult, WorkflowTelemetryOption } from "../types.js";
 
 export type WorkflowEngine = "legacy" | "world";
 
@@ -74,6 +74,7 @@ export interface WorkflowWorldModule {
 /** Options par appel de WorkflowKit.run. */
 export interface WorkflowRunDispatchOptions {
   engine?: WorkflowEngine;
+  telemetry?: WorkflowTelemetryOption;
 }
 
 export type { Workflow, WorkflowRunOptions, WorkflowRunResult };

--- a/packages/core/src/workflows/kit/worldTelemetry.ts
+++ b/packages/core/src/workflows/kit/worldTelemetry.ts
@@ -1,0 +1,68 @@
+import {
+  context as otelContext,
+  trace,
+  type Span,
+  type Context,
+} from "@opentelemetry/api";
+
+import type { WorkflowTelemetryResolvedConfig } from "../telemetry.js";
+
+const TRACER_NAME = "@ai-kit/workflow";
+
+function toJsonAttribute(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Ouvre le span racine nommé pour un run world.
+ * Le span doit être terminé par l'appelant (via span.end()).
+ * Envelopper adapter.run() dans otelContext.with(rootContext, fn) pour
+ * que le SDK Vercel sérialise ce traceparent dans le run durable.
+ */
+export function startWorldRootSpan(
+  config: WorkflowTelemetryResolvedConfig,
+  input: unknown,
+): { span: Span; rootContext: Context } {
+  const tracer = trace.getTracer(TRACER_NAME);
+
+  const span = tracer.startSpan(config.traceName, {
+    attributes: {
+      name: config.traceName,
+      "ai_kit.workflow.id": config.traceName,
+    },
+  });
+
+  if (config.metadata) {
+    span.setAttribute("metadata", toJsonAttribute(config.metadata));
+    for (const [key, val] of Object.entries(config.metadata)) {
+      const safe = key.replace(/\s+/g, "_").replace(/[^\w./-]/g, "_");
+      const primitive =
+        typeof val === "string" || typeof val === "number" || typeof val === "boolean"
+          ? val
+          : toJsonAttribute(val);
+      span.setAttribute(`ai_kit.workflow.metadata.${safe}`, primitive);
+    }
+  }
+
+  if (config.userId) {
+    span.setAttribute("langfuse.user.id", config.userId);
+    span.setAttribute("user.id", config.userId);
+    span.setAttribute("ai_kit.workflow.user_id", config.userId);
+  }
+
+  if (config.tags && config.tags.length > 0) {
+    span.setAttribute("langfuse.trace.tags", toJsonAttribute(config.tags));
+  }
+
+  if (config.recordInputs) {
+    span.setAttribute("input", toJsonAttribute(input));
+  }
+
+  const rootContext = trace.setSpan(otelContext.active(), span);
+
+  return { span, rootContext };
+}

--- a/packages/core/src/workflows/telemetry.ts
+++ b/packages/core/src/workflows/telemetry.ts
@@ -21,6 +21,7 @@ export interface WorkflowTelemetryResolvedConfig {
   recordInputs: boolean;
   recordOutputs: boolean;
   userId?: string;
+  tags?: string[];
 }
 
 interface ResolveTelemetryOptionsParams {
@@ -138,6 +139,10 @@ export const resolveWorkflowTelemetryConfig = ({
 
   const resolvedUserId = overrideOverrides?.userId ?? baseOverrides?.userId;
 
+  const resolvedTags =
+    overrideOverrides?.tags ??
+    baseOverrides?.tags;
+
   const hasMetadata = Object.keys(metadata).length > 0;
   const resolvedTraceName = overrideOverrides?.traceName ?? baseOverrides?.traceName ?? workflowId;
 
@@ -152,6 +157,7 @@ export const resolveWorkflowTelemetryConfig = ({
     recordInputs: resolvedRecordInputs,
     recordOutputs: resolvedRecordOutputs,
     userId: resolvedUserId,
+    tags: resolvedTags,
   };
 };
 

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -44,6 +44,7 @@ export interface WorkflowTelemetryOverrides {
   recordInputs?: boolean;
   recordOutputs?: boolean;
   userId?: string;
+  tags?: string[];
 }
 
 export type WorkflowTelemetryOption =


### PR DESCRIPTION
## Résumé

- Ajoute une trace racine nommée (`traceName`, `metadata`, `userId`, `tags`, `input`/`output`) aux runs durables du moteur world dans `WorkflowKit`
- Le span est créé côté dispatch ; la propagation traceparent W3C du SDK Vercel assure automatiquement le parentage des spans `STEP` et `ai.generateText` sous la trace racine
- Opt-in strict : aucune option `telemetry` → comportement identique à aujourd'hui, 0 overhead
- Chemin legacy, `workflow-world`, et OpenAI : inchangés

## Détails techniques

- Nouveau fichier : `src/workflows/kit/worldTelemetry.ts` — helper `startWorldRootSpan`
- Types : `tags?: string[]` ajouté à `WorkflowTelemetryOverrides` et `WorkflowTelemetryResolvedConfig`
- `WorkflowRunDispatchOptions` : nouveau champ `telemetry?: WorkflowTelemetryOption`
- 8 nouveaux tests TDD (24 tests sur WorkflowKit.test.ts, 159 au total)

## ⚠️ Validation manuelle requise avant merge `dev` → `main`

Avant de merger vers `main` (ce qui publierait 1.10.0 sur npm) :
1. Pointer un world DB réel (postgres/mongo) + Langfuse configuré
2. Appeler `kit.runAndWait(monWorkflow, args, { telemetry: { traceName: "mon-workflow", userId: "...", tags: ["..."] } })`
3. Vérifier dans Langfuse que les spans `STEP {name}` et `ai.generateText` apparaissent **en enfants** de la trace racine nommée (arbre, pas traces liées)
4. Si spans en lien seulement → appliquer fallback D (SpanProcessor enrichissant via baggage OTel — documenté dans la spec)

Spec : `docs/superpowers/specs/2026-06-03-world-workflow-telemetry-design.md`