### PR TITLE
fix(core): enable supportsStructuredOutputs for Scaleway — 1.9.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai_kit/core",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/agents/scaleway-structured-output.integration.test.ts
+++ b/packages/core/src/agents/scaleway-structured-output.integration.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { Output, generateText } from "ai";
+import { z } from "zod";
+import { scaleway } from "../shared/utils/provider/scaleway.js";
+
+const apiKey = process.env.SCALEWAY_API_KEY;
+
+// Tests contre l'API Scaleway réelle — nécessite SCALEWAY_API_KEY
+describe.skipIf(!apiKey)("Scaleway structured output (intégration)", () => {
+  it(
+    "retourne un objet JSON valide avec llama (non-thinking)",
+    async () => {
+      const schema = z.object({
+        city: z.string(),
+        country: z.string(),
+      });
+
+      const result = await generateText({
+        model: scaleway("llama-3.3-70b-instruct"),
+        prompt: "What is the capital of France? Return city and country.",
+        output: Output.object({ schema }),
+        maxOutputTokens: 100,
+      });
+
+      expect(result.output).toMatchObject({
+        city: expect.any(String),
+        country: expect.any(String),
+      });
+    },
+    30_000,
+  );
+
+  it(
+    "retourne un objet JSON valide avec qwen3 (thinking model)",
+    async () => {
+      const schema = z.object({
+        city: z.string(),
+        country: z.string(),
+      });
+
+      const result = await generateText({
+        model: scaleway("qwen3-235b-a22b-instruct-2507"),
+        prompt: "What is the capital of France? Return city and country.",
+        output: Output.object({ schema }),
+        maxOutputTokens: 512,
+      });
+
+      expect(result.output).toMatchObject({
+        city: expect.any(String),
+        country: expect.any(String),
+      });
+    },
+    60_000,
+  );
+});

--- a/packages/core/src/shared/utils/provider/scaleway.ts
+++ b/packages/core/src/shared/utils/provider/scaleway.ts
@@ -21,6 +21,7 @@ const baseScaleway = createOpenAICompatible({
   apiKey: process.env.SCALEWAY_API_KEY!,
   baseURL: "https://api.scaleway.ai/v1",
   name: "scaleway",
+  supportsStructuredOutputs: true,
 });
 
 type BaseScalewayProvider = typeof baseScaleway;


### PR DESCRIPTION
## Summary

- Active `supportsStructuredOutputs: true` sur le provider Scaleway (`createOpenAICompatible`)
- Sans ce flag, l'AI SDK tombait en mode `json_object` (fallback dégradé) → warning dans les logs + certains modèles (llama) retournaient une structure function-call au lieu du schéma attendu
- Scaleway supporte bien `response_format: { type: "json_schema" }` — le flag était simplement absent
- Ajout d'un test d'intégration qui valide le structured output avec llama et qwen3 (thinking model)

## Test plan

- [x] Test d'intégration llama-3.3-70b-instruct : retourne `{city, country}` correct
- [x] Test d'intégration qwen3-235b (thinking model) : fonctionne aussi
- [x] Tests unitaires existants : tous passent (12/12)
- [x] Plus aucun warning `AI SDK Warning: The feature "responseFormat" is not supported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)